### PR TITLE
Fix reference problems

### DIFF
--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -40,8 +40,6 @@ class Channel
 		void							addToBanned(std::string &banned_name);
 		void							removeFromBanned(std::string &banned_name);
 		bool							isBanned(std::string &banned_name);
-		/* Channel attributes */
-		void							updateTopic(std::string &topic);
 };
 
 #endif

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -24,7 +24,7 @@ class Channel
 		std::vector<std::string>&		getOperators() ;
 		std::vector<std::string>&		getBannedUsers() ;
 		std::map <std::string, Client>&	getClientList();
-		void							setTopic(std::string newTopic);
+		void							setTopic(std::string& newTopic);
 		bool							doesClientExist(std::string &clientName);
 		/* Manage client in Channel */
 		void							addClientToChannel(Client &client);
@@ -40,6 +40,8 @@ class Channel
 		void							addToBanned(std::string &banned_name);
 		void							removeFromBanned(std::string &banned_name);
 		bool							isBanned(std::string &banned_name);
+		/* Channel attributes */
+		void							updateTopic(std::string &topic);
 };
 
 #endif

--- a/includes/Commands.hpp
+++ b/includes/Commands.hpp
@@ -15,7 +15,7 @@ struct cmd_struct
 };
 
 int		parseCommand(std::string cmd_line, cmd_struct &cmd_infos);
-Client	retrieveClient(Server *server, int const client_fd);
+Client&	retrieveClient(Server *server, int const client_fd);
 std::string	findNickname(std::string msg_to_parse);
 // void	ban(Server server, cmd_struct cmd_infos);
 void	invite(Server *server, int const client_fd, cmd_struct cmd_infos);

--- a/includes/Numerical_replies.hpp
+++ b/includes/Numerical_replies.hpp
@@ -14,7 +14,7 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define ERR_NONICKNAMEGIVEN(client) ("431 " + client + " :There is no nickname.\r\n")
 # define ERR_ERRONEUSNICKNAME(client, nick) ("432 " + client + " " + nick + " :Erroneus nickname\r\n")
 # define ERR_NICKNAMEINUSE(client, nick) ("433 " + client + " " + nick + " :Nickname is already in use.\r\n")
-# define RPL_NICK(oclient, uclient, client) (":" + oclient + "!" + uclient + "@localhost :" + oclient + " changed their nickname to " + client + "\r\n")
+# define RPL_NICK(oclient, uclient, client) (":" + oclient + "!" + uclient + "@localhost NICK " +  client + "\r\n")
 
 // TOPIC
 # define RPL_TOPIC(client, channel, topic) (" 332 " + client + " " + channel + " " + topic + "\r\n")

--- a/srcs/Channel.cpp
+++ b/srcs/Channel.cpp
@@ -22,17 +22,32 @@ Channel::~Channel() {}
 */
 
 std::string&						Channel::getName() 			{ return (_name); }
-std::string&						Channel::getTopic() 		{ return (_topic); }
+std::string&						Channel::getTopic() 		{ 
+	std::cout << _topic << std::endl;
+	std::cout << "Wouihoo |" << _topic << "|" << std::endl;
+	return (_topic); 
+	}
 std::map <std::string, Client>&		Channel::getClientList()	{ return (_clientList); }
 std::vector<std::string>&			Channel::getBannedUsers()	{ return (_banned_users); }
 std::vector<std::string>&			Channel::getOperators() 	{ return (_operators); }
 
-void							Channel::setTopic(std::string newTopic)
+void							Channel::setTopic(std::string& newTopic)
 {
-	_topic = newTopic; 
+	_topic = newTopic;
+	// std::cout << "Woohoo " << _topic << std::endl;
 	return ;
 }
 
+
+
+void							Channel::updateTopic(std::string &topic)
+{
+	
+	this->setTopic(topic);
+	
+	std::cout << "The new topic is  " << BLUE << this->getTopic() << RESET << std::endl;
+
+}
 bool		Channel::doesClientExist(std::string &clientName)
 {	
 	if (_clientList.size() == 0)

--- a/srcs/Channel.cpp
+++ b/srcs/Channel.cpp
@@ -22,32 +22,16 @@ Channel::~Channel() {}
 */
 
 std::string&						Channel::getName() 			{ return (_name); }
-std::string&						Channel::getTopic() 		{ 
-	std::cout << _topic << std::endl;
-	std::cout << "Wouihoo |" << _topic << "|" << std::endl;
-	return (_topic); 
-	}
+std::string&						Channel::getTopic() 		{ return (_topic); }
 std::map <std::string, Client>&		Channel::getClientList()	{ return (_clientList); }
 std::vector<std::string>&			Channel::getBannedUsers()	{ return (_banned_users); }
 std::vector<std::string>&			Channel::getOperators() 	{ return (_operators); }
 
-void							Channel::setTopic(std::string& newTopic)
+void		Channel::setTopic(std::string& newTopic)
 {
 	_topic = newTopic;
-	// std::cout << "Woohoo " << _topic << std::endl;
-	return ;
 }
 
-
-
-void							Channel::updateTopic(std::string &topic)
-{
-	
-	this->setTopic(topic);
-	
-	std::cout << "The new topic is  " << BLUE << this->getTopic() << RESET << std::endl;
-
-}
 bool		Channel::doesClientExist(std::string &clientName)
 {	
 	if (_clientList.size() == 0)

--- a/srcs/commands/invite.cpp
+++ b/srcs/commands/invite.cpp
@@ -14,7 +14,7 @@ static std::string	findChannel(std::string msg_to_parse);
  */
 void	invite(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
-	Client		client			= retrieveClient(server, client_fd);
+	Client&		client			= retrieveClient(server, client_fd);
 	std::string	client_nickname	= client.getNickname();
 	std::string channel_name	= findChannel(cmd_infos.message);
 	std::string invited_client	= findNickname(cmd_infos.message);

--- a/srcs/commands/list.cpp
+++ b/srcs/commands/list.cpp
@@ -27,7 +27,7 @@ static std::string	getRplList(std::string client_nick, std::map<std::string, Cha
 void		list(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
 	std::string channel_to_display	= findAnyChannel(cmd_infos.message);
-	Client		client 				= retrieveClient(server, client_fd);
+	Client&		client 				= retrieveClient(server, client_fd);
 	std::string client_nick 		= client.getNickname();
 	std::string	RPL_LISTSTART		= "321 " + client_nick + " Channel :Users Name\r\n";
 	std::string	RPL_LIST;

--- a/srcs/commands/nick.cpp
+++ b/srcs/commands/nick.cpp
@@ -41,9 +41,9 @@ static bool	isAlreadyUsed(Server *server, std::string new_nickname);
 void	nick(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
 	std::string nickname	= retrieveNickname(cmd_infos.message);
-	Client		client		= retrieveClient(server, client_fd);
+	Client&		client		= retrieveClient(server, client_fd);
 
-	if (nickname.empty()) {
+	if (nickname.empty()) {	
 		sendServerRpl(client_fd, ERR_NONICKNAMEGIVEN(client.getNickname()));
 	} 
 	else if (containsInvalidCharacters(nickname)) {

--- a/srcs/commands/ping.cpp
+++ b/srcs/commands/ping.cpp
@@ -26,7 +26,7 @@ int	ping(int const client_fd, cmd_struct &cmd)
 	
 	// renvoyer un PONG avec le même TOKEN
 	std::string pong_reply = "PONG" + cmd.message + "\r\n";
-	send(client_fd, pong_reply.c_str(), pong_reply.size(), 0);
+	sendServerRpl(client_fd, pong_reply);
 	
 	return (SUCCESS);
 }

--- a/srcs/commands/topic.cpp
+++ b/srcs/commands/topic.cpp
@@ -79,15 +79,12 @@ void	topic(Server *server, int const client_fd, cmd_struct cmd_infos)
 	{
 		// erase le topic
 		topic.clear();
-		channel->second.updateTopic(topic);
+		channel->second.setTopic(topic);
 		sendServerRpl(client_fd,  RPL_NOTOPIC(client_nickname, channel_name));
 	}
 	else
 	{
 		// reattribuer le topic
-		// channel->second.updateTopic(topic);
-		
-
 		channel->second.setTopic(topic);
 		sendServerRpl(client_fd,  RPL_NEWTOPIC(client_nickname, channel_name, topic));
 	}

--- a/srcs/commands/topic.cpp
+++ b/srcs/commands/topic.cpp
@@ -38,7 +38,7 @@ void	topic(Server *server, int const client_fd, cmd_struct cmd_infos)
 	std::string channel_name;
 	std::string	topic;
 	
-	Client		client = retrieveClient(server, client_fd);
+	Client&		client = retrieveClient(server, client_fd);
 	std::string client_nickname = client.getNickname();
 
 	// ETAPE 1 - PARSER POUR TROUVER UN EVENTUEL CHANNEL_NAME
@@ -91,14 +91,6 @@ void	topic(Server *server, int const client_fd, cmd_struct cmd_infos)
 		channel->second.setTopic(topic);
 		sendServerRpl(client_fd,  RPL_NEWTOPIC(client_nickname, channel_name, topic));
 	}
-}
-
-Client	retrieveClient(Server *server, int const client_fd)
-{
-	std::map<const int, Client>	client_list = server->getClients();
-	std::map<const int, Client>::iterator it_client = client_list.find(client_fd);
-	Client client = it_client->second;
-	return (client);
 }
 
 // Possible output : | #test :New topic|

--- a/srcs/commands/topic.cpp
+++ b/srcs/commands/topic.cpp
@@ -50,7 +50,7 @@ void	topic(Server *server, int const client_fd, cmd_struct cmd_infos)
 	}
 	
 	// ETAPE 2 - RECUPERER LE CHANNEL GRACE AU CHANNEL NAME
-	std::map<std::string, Channel>			 channels = server->getChannels();
+	std::map<std::string, Channel>&			 channels = server->getChannels();
 	std::map<std::string, Channel>::iterator channel = channels.find(channel_name);
 	// // [!] Si channel n'existe pas, renvoyer une erreur
 	if (channel == channels.end())
@@ -68,21 +68,26 @@ void	topic(Server *server, int const client_fd, cmd_struct cmd_infos)
 
 	// Gérer le topic
 	topic = findTopic(cmd_infos.message);
+	
 	if (topic.empty())
 	{
 		// afficher le topic
-		sendServerRpl(client_fd,  RPL_TOPIC(client_nickname, channel_name, topic));
-		std::cout << "The topic of this channel is " << topic << std::endl;
+		sendServerRpl(client_fd,  RPL_TOPIC(client_nickname, channel_name, channel->second.getTopic()));
+		std::cout << "The topic of this channel is " << channel->second.getTopic() << std::endl;
 	}
 	else if (topic == ":")
 	{
 		// erase le topic
 		topic.clear();
+		channel->second.updateTopic(topic);
 		sendServerRpl(client_fd,  RPL_NOTOPIC(client_nickname, channel_name));
 	}
 	else
 	{
 		// reattribuer le topic
+		// channel->second.updateTopic(topic);
+		
+
 		channel->second.setTopic(topic);
 		sendServerRpl(client_fd,  RPL_NEWTOPIC(client_nickname, channel_name, topic));
 	}

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -8,3 +8,13 @@ void	sendServerRpl(int const client_fd, std::string reply)
 	std::cout << "[Server] Message sent to client " \
 			<< client_fd << " >> " << CYAN << reply << RESET << std::endl;
 }
+
+
+Client&	retrieveClient(Server *server, int const client_fd)
+{
+	std::map<const int, Client>&		client_list = server->getClients();
+	std::map<const int, Client>::iterator it_client = client_list.find(client_fd);
+	;
+	Client &client = it_client->second;
+	return (client);
+}


### PR DESCRIPTION
- **Topic command** : the topic was changed but not kept in memory => actually it is because we work with a copy of Channel, so ofc the original channel did not have the change
- **Nick command** : same issue w/ the nickname + the `RPL_NICK` was wrong, instead of a generic message, the server had to send the` NICK `command back to the Client
- => **put the function retrieveClient() in utils.cpp** because it is used in many functions and corrected the proto by adding references when needed