### PR TITLE
Fixed infinite loop 

### DIFF
--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -35,8 +35,7 @@ class Server
 		int			manageServerLoop();
 		// Manage Clients functions
 		void		addClient(int client_socket, std::vector<pollfd> &poll_fds);
-		void		delClient(std::vector<pollfd> &poll_fds, std::vector<pollfd>::iterator &it);
-		// void		fillClients(std::map<const int, Client> &client_list, int client_fd, std::vector<std::string> cmds);
+		void 		delClient(std::vector<pollfd> &poll_fds, int current_fd);
 		void 		fillClients(std::map<const int, Client> &client_list, int client_fd, std::string cmd);
 		// Parsing & Commands functions
 		void		parseMessage(const int client_fd, std::string message);

--- a/srcs/ManageServer.cpp
+++ b/srcs/ManageServer.cpp
@@ -97,32 +97,31 @@ int Server::manageServerLoop()
 					if (read_count <= FAILURE) // when recv returns an error
 					{
 						std::cerr << RED << "Recv() failed [456]" << RESET << std::endl;
-						delClient(poll_fds, it);
+						delClient(poll_fds, it->fd);
 						if ((unsigned int)(poll_fds.size() - 1) == 0)
 							break;
 					}
 					else if (read_count == 0) // when a client disconnects
 					{
-						delClient(poll_fds, it);
+						delClient(poll_fds, it->fd);
 						std::cout << "Disconnected\n";
 						if ((unsigned int)(poll_fds.size() - 1) == 0)
 							break;
 					}
 					else
 					{
-						print("Recv : ", it->fd, message); // si affichage incoherent regarder ici
+						print("[CLIENT] Recv : ", it->fd, message); // si affichage incoherent regarder ici
 						try 
 						{
 							parseMessage(it->fd, message);
 						}
 						catch(const std::exception& e) 
 						{ 
-							std::cout << "Caught exception : " << std::endl;
+							std::cout << "[SERVER] Caught exception : ";
 							std::cerr << e.what() << std::endl;
-							delClient(poll_fds, it); // NOTE: are we sure we want to delete the client in that case?
-							std::cout << "Client deleted." << std::endl;
-							if ((unsigned int)(poll_fds.size() - 1) == 0)
-								break;
+							delClient(poll_fds, it->fd);
+							std::cout << "[SERVER] Client #"<< it->fd << " deleted." << std::endl;
+							break ;
 						}
 						it++;
 					}
@@ -137,7 +136,7 @@ int Server::manageServerLoop()
 				}
 				else
 				{
-					delClient(poll_fds, it);
+					delClient(poll_fds, it->fd);
 					if ((unsigned int)(poll_fds.size() - 1) == 0)
 						break;
 				}

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -110,17 +110,17 @@ void Server::addClient(int client_socket, std::vector<pollfd> &poll_fds)
 	std::cout << PURPLE << "ADDED CLIENT SUCCESSFULLY" << RESET << std::endl;
 }
 
-void Server::delClient(std::vector<pollfd> &poll_fds, std::vector<pollfd>::iterator &it)
+void Server::delClient(std::vector<pollfd> &poll_fds, int current_fd)
 {
 	std::cout << "je suis dans le del\n";
-	std::cout << "Deconnection of client : " << it->fd << std::endl;
-	int key = it->fd;
+	std::cout << "Deconnection of client : " << current_fd << std::endl;
+	int key = current_fd;
 	std::vector<pollfd>::iterator iterator;
 	for (iterator = poll_fds.begin(); iterator != poll_fds.end(); iterator++)
 	{
-		if (iterator->fd == it->fd)
+		if (iterator->fd == current_fd)
 		{
-			close(it->fd);
+			close(current_fd);
 			poll_fds.erase(iterator);
 			_clients.erase(key);
 			break;


### PR DESCRIPTION
**BUG** : Infinite loop triggered when 1 Client made an error caught in the try and catch (for instance, the password is wrong, so client is invalid => must be rejected by the Server).

**LOGIC** : When the Client is invalid, its fd is deleted in the DelClient() function. It is also deleted from the Poll_fd vector. And it happens, as it should. But, as we are stuck in the same loop of Poll_fd vectors, whose iterators for begin() and end() have not been updated, the program continue to loop and tries to read values that have been erased. That's why the it->fd value was 8345352125 and error messages were triggered.
```cpp
std::vector<pollfd> poll_fds;
pollfd server_poll_fd;
poll_fds.push_back(server_poll_fd);

while (1)
{
  // some code in between
 std::vector<pollfd>::iterator it = poll_fds.begin();
 while (it != poll_fds.end()) // the loop in question
 {
    // our code
 }
}
```

**RESOLUTION** : 

1. Added a break in ManageServerLoop 

```cpp
try 
{
 parseMessage(it->fd, message);
}
catch(const std::exception& e) 
{ 
 std::cerr << e.what() << std::endl;
 delClient(poll_fds, it->fd);
 std::cout << "[SERVER] Client #"<< it->fd << " deleted." << std::endl;
 break ; // added in the commit
}
```

2. Changed proto of function Server::DelClient / This is more of a cosmetic fix, because we were passing through a reference to an iterator when an **int fd** (aka it->fd) was only needed.
```cpp
void Server::delClient(std::vector<pollfd> &poll_fds, int current_fd); // new proto
```