### PR TITLE
[NAMES] command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ SRCS		= main.cpp Client.cpp ManageServer.cpp Server.cpp parsing.cpp Channel.cpp 
 				commands/list.cpp 	\
 				commands/invite.cpp	\
 				commands/nick.cpp	\
-				commands/pass.cpp
+				commands/pass.cpp	\
+				commands/names.cpp
 
 DIR_SRCS	= srcs/
 

--- a/includes/Commands.hpp
+++ b/includes/Commands.hpp
@@ -3,7 +3,7 @@
 
 # include "Irc.hpp"
 # include "Server.hpp"
-# define VALID_LEN 17
+# define VALID_LEN 15
 
 class Server;
 
@@ -22,6 +22,7 @@ void	invite(Server *server, int const client_fd, cmd_struct cmd_infos);
 void	join(Server *server, int const client_fd, cmd_struct cmd_infos);
 // void	kick(Server server, cmd_struct cmd_infos);
 void	list(Server *server, int const client_fd, cmd_struct cmd_infos);
+void	names(Server *server, int const client_fd, cmd_struct cmd_infos);
 void	nick(Server *server, int const client_fd, cmd_struct cmd_infos);
 // void	oper(Server server, cmd_struct cmd_infos);
 int		pass(Server *server, int const client_fd, cmd_struct cmd_infos);

--- a/includes/Numerical_replies.hpp
+++ b/includes/Numerical_replies.hpp
@@ -10,6 +10,11 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define ERR_USERONCHANNEL(client, nick, channel) ("443 " + client + " " + nick + " " + channel + " :Is already on channel\r\n")
 # define RPL_INVITING(client, nick, channel) ("341 " + client + " " + nick + " " + channel + " :Is invited to a channel!\r\n")
 
+// JOIN
+# define RPL_JOIN(username, nick, channel) (":" + nick + "!" + username + "@localhost JOIN " +  channel + "\r\n")
+# define ERR_BANNEDFROMCHAN(client, channel) ("474 " + client + " " + channel + " :Cannot join channel (+b)")
+# define ERR_BADCHANNELKEY(client, channel) ("475 " + client + " " + channel + " :Cannot join channel (+k)")
+
 // NAMES
 # define RPL_NAMREPLY(client, symbol, channel, list_of_nicks) ("353 " + client + " " + symbol + " " + channel + " :" + list_of_nicks + ".\r\n")
 # define RPL_ENDOFNAMES(client, channel) ("366 " + client + " " + channel + " :End of /NAMES list\r\n")
@@ -27,10 +32,10 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define RPL_PONG(token) ("PONG " + token + "\r\n")
 
 // TOPIC
-# define RPL_TOPIC(client, channel, topic) (" 332 " + client + " " + channel + " " + topic + "\r\n")
-# define RPL_NOTOPIC(client, channel) (" 331 " + client + " " + channel + ": The topic has been cleared.\r\n")
+# define RPL_TOPIC(client, channel, topic) ("332 " + client + " #" + channel + " " + topic + "\r\n")
+# define RPL_NOTOPIC(client, channel) ("331 " + client + " " + channel + ": The topic has been cleared.\r\n")
 # define RPL_NEWTOPIC(client, channel, topic) (client + " " + channel + " New topic is " + topic + "\r\n")
-
+# define RPL_DISPLAYTOPIC(client_id, channel) (client_id + " TOPIC " +  channel + "\r\n")
 
 
 

--- a/includes/Numerical_replies.hpp
+++ b/includes/Numerical_replies.hpp
@@ -10,6 +10,10 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define ERR_USERONCHANNEL(client, nick, channel) ("443 " + client + " " + nick + " " + channel + " :Is already on channel\r\n")
 # define RPL_INVITING(client, nick, channel) ("341 " + client + " " + nick + " " + channel + " :Is invited to a channel!\r\n")
 
+// NAMES
+# define RPL_NAMREPLY(client, symbol, channel, list_of_nicks) ("353 " + client + " " + symbol + " " + channel + " :" + list_of_nicks + ".\r\n")
+# define RPL_ENDOFNAMES(client, channel) ("366 " + client + " " + channel + " :End of /NAMES list\r\n")
+
 // NICK
 # define ERR_NONICKNAMEGIVEN(client) ("431 " + client + " :There is no nickname.\r\n")
 # define ERR_ERRONEUSNICKNAME(client, nick) ("432 " + client + " " + nick + " :Erroneus nickname\r\n")

--- a/srcs/ManageServer.cpp
+++ b/srcs/ManageServer.cpp
@@ -145,18 +145,18 @@ int Server::manageServerLoop()
 				it++;
 		}
 		poll_fds.insert(poll_fds.end(), new_pollfds.begin(), new_pollfds.end()); // Add the range of NEW_pollfds in poll_fds (helps recalculating poll_fds.end() in the for loop)
-		std::cout << "j'ai insert\n"
-				  << std::endl;
+		// std::cout << "j'ai insert\n"
+		// 		  << std::endl;
 
-		// print list of our client
-		std::cout << "Map size : " << _clients.size() << std::endl;
-		std::cout << "print list of our client" << std::endl;
-		std::map<const int, Client>::iterator it_map;
-		for (it_map = _clients.begin(); it_map != _clients.end(); it_map++)
-		{
-			std::cout << "Key : " << it_map->first << std::endl;
-			it_map->second.printClient();
-		}
+		// // print list of our client
+		// std::cout << "Map size : " << _clients.size() << std::endl;
+		// std::cout << "print list of our client" << std::endl;
+		// std::map<const int, Client>::iterator it_map;
+		// for (it_map = _clients.begin(); it_map != _clients.end(); it_map++)
+		// {
+		// 	std::cout << "Key : " << it_map->first << std::endl;
+		// 	it_map->second.printClient();
+		// }
 	}
 	return (SUCCESS);
 }

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -251,6 +251,7 @@ void Server::execCommand(int const client_fd, std::string cmd_line)
 		"KILL",
 		"LIST",
 		"MODE",
+		"NAMES",
 		"NICK",
 		"PART",
 		"PING",
@@ -259,9 +260,6 @@ void Server::execCommand(int const client_fd, std::string cmd_line)
 		"QUIT",
 		"TOPIC",
 		"USER",
-		"WHO",
-		"WHOIS",
-		"WHOWAS"
 		};
 
 	cmd_struct cmd_infos;
@@ -283,18 +281,16 @@ void Server::execCommand(int const client_fd, std::string cmd_line)
 	// case 3: kick(this, cmd_infos); break;
 	// case 4: kill(cmd_infos); break;
 	case 5: list(this, client_fd, cmd_infos); break;
-	// case 6: mode(cmd_infos); break;
-	case 7: nick(this, client_fd, cmd_infos); break;
-	// case 8: part(cmd_infos); break;
-	case 9: ping(client_fd, cmd_infos); break;
-	// case 10: oper(this, cmd_infos); break;
-  // case 11: privmsg(cmd_infos); break;
-	// case 12: quit(this, cmd_infos); break;
-	case 13: topic(this, client_fd, cmd_infos); break;
-	// case 14: user(cmd_infos); break;
-	// case 15: who(cmd_infos); break;
-	// case 16: whois(cmd_infos); break;
-	// case 17: whowas(cmd_infos); break;
+	// case 6: mode(this, client_fd, cmd_infos); break;
+	case 7: names(this, client_fd, cmd_infos); break;
+	case 8: nick(this, client_fd, cmd_infos); break;
+	// case 9: part(cmd_infos); break;
+	case 10: ping(client_fd, cmd_infos); break;
+	// case 11: oper(this, cmd_infos); break;
+  	// case 12: privmsg(cmd_infos); break;
+	// case 13: quit(this, cmd_infos); break;
+	case 14: topic(this, client_fd, cmd_infos); break;
+	// case 15: user(cmd_infos); break;
 	default:
 		std::cout << PURPLE << "This command is not supported by our services." << RESET << std::endl;
 	}

--- a/srcs/commands/join.cpp
+++ b/srcs/commands/join.cpp
@@ -4,9 +4,10 @@
 
 bool			containsAtLeastOneAlphaChar(std::string str);
 std::string		getChannelName(std::string msg_to_parse);
+std::string		retrieveKey(std::string msg_to_parse);
 void			addChannel(Server *server, std::string const &channelName);
 void			addClientToChannel(Server *server, std::string &channelName, Client &client);
-void			printChannel(Server *server, std::string &channelName);
+void			sendChanInfos(Channel &channel, std::string channel_name, Client &client);
 /**
  * @brief The JOIN command indicates that the client wants to join the given channel(s), 
  * 	each channel using the given key for it. The server receiving the command checks 
@@ -42,80 +43,95 @@ void			printChannel(Server *server, std::string &channelName);
  */
 void	join(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
-	// Pour l'instant, on ne teste que les inputs faciles type "JOIN #foo"
-	std::string channelName = getChannelName(cmd_infos.message);
-
-	// Récupérer le Client client grace au client fd
-	std::map<const int, Client>	client_list = server->getClients();
-	std::map<const int, Client>::iterator it_client = client_list.find(client_fd);
-	Client client = it_client->second;
-
-	// Récupérer le bon channel grâce au channel name
-	std::map<std::string, Channel>::iterator it = server->getChannels().find(channelName);
-	if (it == server->getChannels().end()) // si on ne le trouve pas, créer le channel
-		addChannel(server, channelName);
-		// server->addChannel(channelName);
-	
-	// vérifier si le client est banned avant de le join au channel
+	Client		client 			= retrieveClient(server, client_fd);
 	std::string client_nickname = client.getNickname();
-	std::map<std::string, Channel>::iterator it_chan = server->getChannels().find(channelName);
-	if (it_chan->second.isBanned(client_nickname) == true) {
-		std::cout << client.getNickname() << " is banned from " << channelName << std::endl; 
-		return ;
-	} 
-	else {
-		// addClientToChannel(server, channelName, client);
-		server->addClientToChannel(channelName, client);
-		it_chan->second.addFirstOperator(client.getNickname()); // FIXME: pourquoi le rajouter en oper par défaut au channel ?
-		printChannel(server, channelName);
+	std::string	channel_name;
+
+	if (containsAtLeastOneAlphaChar(cmd_infos.message) == false)
+		sendServerRpl(client_fd, ERR_NEEDMOREPARAMS(client_nickname, cmd_infos.name));
+	while (containsAtLeastOneAlphaChar(cmd_infos.message) == true)
+	{
+		channel_name.clear();
+		channel_name = getChannelName(cmd_infos.message);
+
+		// erase de la string le channel = "#foo,#bar" devient "#,#bar"
+		cmd_infos.message.erase(cmd_infos.message.find(channel_name), channel_name.length()); 
+		
+		
+		// Récupérer le bon channel grâce au channel name
+		std::map<std::string, Channel>&			 channels 	= server->getChannels();
+		std::map<std::string, Channel>::iterator it			= channels.find(channel_name);
+		if (it == channels.end()) // si on ne le trouve pas, créer le channel
+		{
+			addChannel(server, channel_name);	
+		}
+		// else if (channel.keyModeOn() == true) // vérifier que le client a la bonne key, si mode +k
+		// {
+		// 	std::string key = retrieveKey(cmd_infos.message);
+		// 	if (key != channel.getKey())
+		// 	{
+		// 		sendServerRpl(client_fd, ERR_BADCHANNELKEY(client_nickname, channel_name));
+		// 		continue; // on passe la suite, au prochain channel à ajouter síl y en a un
+		// 	}
+		// 	else // on erase la key de la string
+		// 		cmd_infos.message.erase(cmd_infos.message.find(key), key.length());
+		// }
+
+		// vérifier si le client est banned avant de le join au channel
+		std::map<std::string, Channel>::iterator it_chan = server->getChannels().find(channel_name);
+		if (it_chan->second.isBanned(client_nickname) == true) {
+			sendServerRpl(client_fd, ERR_BANNEDFROMCHAN(client_nickname, channel_name));
+		} 
+		else {
+			addClientToChannel(server, channel_name, client);
+			// if le channel a pas d'operateur :
+			if (it_chan->second.getOperators().empty())
+				it_chan->second.addFirstOperator(client.getNickname());
+			
+			sendChanInfos(it_chan->second, channel_name, client);
+		}
 	}
+	
 }
 
-// VERSION COMPLETE A TESTER SI LA VERSION BASIQUE MARCHE
-// Logique pour l'output 2 : on erase les channels (avec leur keys quand elles en ont) au fur et à mesure qu'on join
-// void	join(Server server, int const client_fd, cmd_struct cmd_infos)
-// {
-// 	std::string channelName;
-
-// 	while (containsAtLeastOneAlphaChar(cmd_infos.message) == false)
-// 	{
-// 		channelName.clear();
-// 		channelName = getChannelName(cmd_infos.message);
-
-// 		// erase de la string le channel = "#foo,#bar" devient "#,#bar"
-// 		cmd_infos.message.erase(cmd_infos.message.find(channelName), channelName.length()); 
-
-// 		// Récupérer le Client client grace au client fd
-// 		std::map<const int, Client>	client_list = server.getClients();
-// 		std::map<const int, Client>::iterator it_client = client_list.find(client_fd);
-// 		Client client = it_client->second;
-
-// 		// Récupérer le bon channel grâce au channel name
-// 		std::map<std::string, Channel>			 channels = server.getChannels();
-// 		std::map<std::string, Channel>::iterator it = channels.find(channelName);
-// 		if (it == channels.end()) // si on ne le trouve pas, créer le channel
-// 			addChannel(server, channelName);
+// If a client’s JOIN command to the server is successful, the server MUST send, in this order:
+// A JOIN message with the client as the message <source> and the channel they have 
+// joined as the first parameter of the message.
+// The channel’s topic (with RPL_TOPIC (332), 
+// and no message if the channel does not have a topic.
+void		sendChanInfos(Channel &channel, std::string channel_name, Client &client)
+{
+	int			client_fd	= client.getClientFd();
+	std::string	nick		= client.getUsername();
+	std::string username	= client.getNickname();
+	std::string	client_id	= ":" + nick + "!" + username + "@localhost";
+ 	
+	sendServerRpl(client_fd, RPL_JOIN(username, nick, channel_name));
+	if (channel.getTopic().empty() == false)
+	{
+		sendServerRpl(client_fd, RPL_TOPIC(client_id, channel_name, channel.getTopic()));
+		sendServerRpl(client_fd, RPL_DISPLAYTOPIC(client_id, channel_name));
+	}
 		
-// 		// vérifier si le client est banned avant de le join au channel
-// 		std::string client_nickname = client.getNickname();
-// 		if (it->second.isBanned(client_nickname) == true) {
-// 			std::cout << client.getNickname() << " is banned from " << channelName << std::endl; 
-// 			return ;
-// 		} 
-// 		else {
-// 			addClientToChannel(server, channelName, client);
-// 			// if le channel a pas d'operateur :
-// 			if (it->second.getOperators().empty())
-// 				it->second.addFirstOperator(client.getNickname());
-// 		}
-// 		// TODO : prevoir check de la key; tester key et erase key du cmd_infos.msg
-// 		// TODO: Attention, cest pas fini quand qqun est add au chan, il y a plein d'infos à lui fournir
-// 		}
-	
-// }
+
+	// TODO: DES QUE NAMES EST FAIT
+	// A list of users currently joined to the channel (with one or more RPL_NAMREPLY (353) 
+	// numerics followed by a single RPL_ENDOFNAMES (366) numeric).
+	// These RPL_NAMREPLY messages sent by the server MUST include the requesting client 
+	// that has just joined the channel.
+
+}
 
 bool		containsAtLeastOneAlphaChar(std::string str)
 {
+	// If +k mode activated, the input is " #foo,#bar fubar,foobar".
+	// But we only want this part : "#foo,#bar"
+	// if (channel.keyModeOn() == true)
+	// {
+	// 	char *channels = const_cast<char *>(str.data());
+	// 	str = strtok(channels, " ");
+	// }
+
 	for (size_t i = 0; i < str.size(); i++)
 	{
 		if (isalpha(str[i]))
@@ -134,10 +150,31 @@ std::string	getChannelName(std::string msg_to_parse)
 	size_t i = 0;
 	while (!isalpha(msg_to_parse[i]))
 		i++;
-	while (isalpha(msg_to_parse[i])) // as soon as there is a space or comma, it means the word is finished
+	while (isalpha(msg_to_parse[i]) || msg_to_parse[i] == '-' || msg_to_parse[i] == '_') // as soon as there is a space or comma, it means the word is finished
 		channel_name += msg_to_parse[i++];
 	std::cout << "The channel name is : |" << channel_name << "|" << std::endl;
 	return (channel_name);
+}
+
+std::string	retrieveKey(std::string msg_to_parse)
+{
+	std::cout << "[RKey] The msg_to_parse looks like this : |" << msg_to_parse << "|" << std::endl;
+	// Expected output 2 : | #,#bar fubar_75,foobar| 
+	// Nous on veut la key "fubar_75" relié à "foo" (erased de la str à ce stade là)
+
+	std::string	key;
+
+	if (msg_to_parse[0] == ' ')
+		msg_to_parse.erase(0, 1); // Expected output : |#f,#bar fubar_75,foobar|
+	
+	int	begin_pos = msg_to_parse.find(" ") + 1; // Expected: begin à |fubar_75,foobar|
+	while (msg_to_parse[begin_pos] || msg_to_parse[begin_pos] != ',')
+	{
+		key += msg_to_parse[begin_pos];
+		begin_pos++;
+	}
+	std::cout << "The key is : |" << key << "|" << std::endl; // Expected : fubar75
+	return (key);
 }
 
 void	addChannel(Server *server, std::string const &channelName)
@@ -158,7 +195,6 @@ void	addClientToChannel(Server *server, std::string &channelName, Client &client
 {
 	std::map<std::string, Channel>::iterator it;
 	it = server->getChannels().find(channelName);
-	std::cout << "it->first = " << it->first << std::endl;
 	std::string client_nickname = client.getNickname();
 	if (it->second.doesClientExist(client_nickname) == false)
 	{
@@ -167,14 +203,4 @@ void	addClientToChannel(Server *server, std::string &channelName, Client &client
 	}
 	else 
 		std::cout << YELLOW << client.getNickname() << "already here\n" << RESET;
-}
-
-
-// NOTE: à qui sert cette fonction ? debug ?
-void	printChannel(Server *server, std::string &channelName)
-{
-	std::map<std::string, Channel>			 	channels = server->getChannels();
-	std::map<std::string, Channel> 				tmp; // NOTE: pourquoi un tmp ?
-	std::map<std::string, Channel>::iterator	it = channels.find(channelName);
-	it->second.printClientList();
 }

--- a/srcs/commands/names.cpp
+++ b/srcs/commands/names.cpp
@@ -5,7 +5,7 @@
 
 static bool			containsAtLeastOneAlphaChar(std::string str);
 static std::string	getChannelName(std::string msg_to_parse);
-static std::string	getSymbol(Channel &channel);
+// static std::string	getSymbol(Channel &channel);
 static std::string	getListOfMembers(Channel &channel);
 /**
  * @brief The NAMES command is used to view the nicknames joined to a channel.
@@ -26,10 +26,10 @@ static std::string	getListOfMembers(Channel &channel);
  */
 void	names(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
-	Client										client = retrieveClient(server, client_fd);
-	std::string									channel_to_name;
-	std::string									symbol;
-	std::string									list_of_members;
+	Client			client				= retrieveClient(server, client_fd);
+	std::string		symbol				= "=";
+	std::string		channel_to_name;
+	std::string		list_of_members;
 
 	while (containsAtLeastOneAlphaChar(cmd_infos.message) == true)
 	{
@@ -42,18 +42,18 @@ void	names(Server *server, int const client_fd, cmd_struct cmd_infos)
 		std::map<std::string, Channel>				channels = server->getChannels();
 		std::map<std::string, Channel>::iterator	channel = channels.find(channel_to_name);
 		if (channel == channels.end()) // + "|| isSecretModeOn(channel_name) == true  && doesClientExist() == false"
-			sendServerRpl(client_fd, RPL_ENDOFNAMES(client.getNickname(), channel_name));
+			sendServerRpl(client_fd, RPL_ENDOFNAMES(client.getNickname(), channel_to_name));
 
-		// find the symbol of said channel (public, secret, or private)
-		symbol.clear();
-		symbol = getSymbol(&channel->second);
+		// find the symbol of said channel (public, secret, or private) //TODO : Dès que MODE est fait
+		// symbol.clear();
+		// symbol = getSymbol(&channel->second);
 
 		// get as a string the list of all members (by nickname)
 		list_of_members.clear();
-		list_of_members = getListOfMembers(&channel->second);
+		list_of_members = getListOfMembers(channel->second);
 
 		sendServerRpl(client_fd, RPL_NAMREPLY(client.getNickname(), symbol, channel_to_name, list_of_members));
-		sendServerRpl(client_fd, RPL_ENDOFNAMES(client.getNickname(), channel_name));
+		sendServerRpl(client_fd, RPL_ENDOFNAMES(client.getNickname(), channel_to_name));
 	}
 	
 }
@@ -70,17 +70,44 @@ static bool		containsAtLeastOneAlphaChar(std::string str)
 
 static std::string getChannelName(std::string msg_to_parse)
 {
-
+	std::cout << "The msg_to_parse looks like this : |" << msg_to_parse << "|" << std::endl;
+	
+	std::string channel_name;
+	
+	size_t i = 0;
+	while (!isalpha(msg_to_parse[i]) || !isdigit(msg_to_parse[i]))
+		i++;
+	while (isalpha(msg_to_parse[i]) || msg_to_parse[i] == '-' || msg_to_parse[i] == '_' || isdigit(msg_to_parse[i]))
+		channel_name += msg_to_parse[i++];
+	std::cout << "The channel name is : |" << channel_name << "|" << std::endl;
+	return (channel_name);
 }
 
-static std::string	getSymbol(Channel &channel)
-{
-	return 
-}
+// static std::string	getSymbol(Channel &channel)
+// {
+// 	return 
+// }
 
 
 static std::string	getListOfMembers(Channel &channel)
 {
-	return 
+	std::map<std::string, Client>&			client_list	= channel.getClientList();
+	std::map<std::string, Client>::iterator	it			= client_list.begin();
+	std::string								nick;
+	std::string								members_list;
+
+	while (it != client_list.end())
+	{
+		nick.clear();
+		nick = it->second.getNickname();
+		members_list += nick;
+		members_list += " ";
+		it++;
+	}
+	std::cout << "The members list is : |" << members_list << "|" << std::endl;
+	if (members_list[members_list.size() - 1] == ' ')
+		members_list.erase(members_list.end()-1);
+	std::cout << "[UPD] The members list is : |" << members_list << "|" << std::endl;
+	return (members_list);
 }
 

--- a/srcs/commands/names.cpp
+++ b/srcs/commands/names.cpp
@@ -1,0 +1,26 @@
+#include "Irc.hpp"
+#include "Channel.hpp"
+#include "Server.hpp"
+#include "Commands.hpp"
+
+/**
+ * @brief The NAMES command is used to view the nicknames joined to a channel.
+ *  If the channel name is invalid or the channel does not exist, one RPL_ENDOFNAMES 
+ * 	numeric containing the given channel name should be returned.
+ * 
+ * 	Syntax: NAMES <channel>{,<channel>}
+ * 	
+ * 	Numeric Replies:
+ * 	
+ * 	RPL_NAMREPLY (353)
+ * 	RPL_ENDOFNAMES (366)
+ * 
+ * 	Examples:
+ * 	[CLIENT] /NAMES #test,#42
+ * 	[SERVER] <client> <symbol> #test :<nick1> <nick2>
+ * 	
+ */
+void	names(Server *server, int const client_fd, cmd_struct cmd_infos)
+{
+
+}

--- a/srcs/commands/names.cpp
+++ b/srcs/commands/names.cpp
@@ -3,6 +3,10 @@
 #include "Server.hpp"
 #include "Commands.hpp"
 
+static bool			containsAtLeastOneAlphaChar(std::string str);
+static std::string	getChannelName(std::string msg_to_parse);
+static std::string	getSymbol(Channel &channel);
+static std::string	getListOfMembers(Channel &channel);
 /**
  * @brief The NAMES command is used to view the nicknames joined to a channel.
  *  If the channel name is invalid or the channel does not exist, one RPL_ENDOFNAMES 
@@ -22,5 +26,61 @@
  */
 void	names(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
+	Client										client = retrieveClient(server, client_fd);
+	std::string									channel_to_name;
+	std::string									symbol;
+	std::string									list_of_members;
+
+	while (containsAtLeastOneAlphaChar(cmd_infos.message) == true)
+	{
+		// find the channel to display names of
+		channel_to_name.clear();
+		channel_to_name = getChannelName(cmd_infos.message);
+		cmd_infos.message.erase(cmd_infos.message.find(channel_to_name), channel_to_name.length()); 
+
+		// Error handling (Inexistent channel, Secret Mode on...)
+		std::map<std::string, Channel>				channels = server->getChannels();
+		std::map<std::string, Channel>::iterator	channel = channels.find(channel_to_name);
+		if (channel == channels.end()) // + "|| isSecretModeOn(channel_name) == true  && doesClientExist() == false"
+			sendServerRpl(client_fd, RPL_ENDOFNAMES(client.getNickname(), channel_name));
+
+		// find the symbol of said channel (public, secret, or private)
+		symbol.clear();
+		symbol = getSymbol(&channel->second);
+
+		// get as a string the list of all members (by nickname)
+		list_of_members.clear();
+		list_of_members = getListOfMembers(&channel->second);
+
+		sendServerRpl(client_fd, RPL_NAMREPLY(client.getNickname(), symbol, channel_to_name, list_of_members));
+		sendServerRpl(client_fd, RPL_ENDOFNAMES(client.getNickname(), channel_name));
+	}
+	
+}
+
+static bool		containsAtLeastOneAlphaChar(std::string str)
+{
+	for (size_t i = 0; i < str.size(); i++)
+	{
+		if (isalpha(str[i]) || str[i] == '_' || str[i] == '-' || isdigit(str[i]))
+			return (true);
+	}
+	return (false);
+}
+
+static std::string getChannelName(std::string msg_to_parse)
+{
 
 }
+
+static std::string	getSymbol(Channel &channel)
+{
+	return 
+}
+
+
+static std::string	getListOfMembers(Channel &channel)
+{
+	return 
+}
+

--- a/srcs/commands/names.cpp
+++ b/srcs/commands/names.cpp
@@ -70,16 +70,17 @@ static bool		containsAtLeastOneAlphaChar(std::string str)
 
 static std::string getChannelName(std::string msg_to_parse)
 {
-	std::cout << "The msg_to_parse looks like this : |" << msg_to_parse << "|" << std::endl;
-	
-	std::string channel_name;
-	
-	size_t i = 0;
-	while (!isalpha(msg_to_parse[i]) || !isdigit(msg_to_parse[i]))
+	std::string	channel_name;
+	size_t		i = 0;
+
+	while (!isalpha(msg_to_parse[i]) && !isdigit(msg_to_parse[i]))
 		i++;
-	while (isalpha(msg_to_parse[i]) || msg_to_parse[i] == '-' || msg_to_parse[i] == '_' || isdigit(msg_to_parse[i]))
-		channel_name += msg_to_parse[i++];
-	std::cout << "The channel name is : |" << channel_name << "|" << std::endl;
+	// while (msg_to_parse[i] && (isalpha(msg_to_parse[i]) || msg_to_parse[i] == '-' || msg_to_parse[i] == '_' || isdigit(msg_to_parse[i])))
+	while (msg_to_parse[i] && isalpha(msg_to_parse[i]))
+	{
+		channel_name += msg_to_parse[i];
+		i++;
+	}
 	return (channel_name);
 }
 
@@ -104,10 +105,8 @@ static std::string	getListOfMembers(Channel &channel)
 		members_list += " ";
 		it++;
 	}
-	std::cout << "The members list is : |" << members_list << "|" << std::endl;
 	if (members_list[members_list.size() - 1] == ' ')
 		members_list.erase(members_list.end()-1);
-	std::cout << "[UPD] The members list is : |" << members_list << "|" << std::endl;
 	return (members_list);
 }
 

--- a/srcs/commands/topic.cpp
+++ b/srcs/commands/topic.cpp
@@ -72,6 +72,7 @@ void	topic(Server *server, int const client_fd, cmd_struct cmd_infos)
 	if (topic.empty())
 	{
 		// afficher le topic
+		// PREVOIR CAR OU CHAN A AFFICHER EST VIDE
 		sendServerRpl(client_fd,  RPL_TOPIC(client_nickname, channel_name, channel->second.getTopic()));
 		std::cout << "The topic of this channel is " << channel->second.getTopic() << std::endl;
 	}
@@ -86,7 +87,8 @@ void	topic(Server *server, int const client_fd, cmd_struct cmd_infos)
 	{
 		// reattribuer le topic
 		channel->second.setTopic(topic);
-		sendServerRpl(client_fd,  RPL_NEWTOPIC(client_nickname, channel_name, topic));
+		sendServerRpl(client_fd,  RPL_TOPIC(client_nickname, channel_name, topic));
+		// sendServerRpl(client_fd,  RPL_NEWTOPIC(client_nickname, channel_name, topic));
 	}
 }
 


### PR DESCRIPTION
### Meaning
The `NAMES` command is used to view the nicknames joined to a channel.

### Behaviour
User1 input: `/NAMES #channel`
Output:
- from **server**:  `353 client symbol channel :<nick> <nick>...` => `353 user1 = channel :user1 user2.`
- from **client** : `[USERS channel] user1 user2.`

At the end of the listing, the server must also send a `RPL_ENDOFNAMES (366): "<client> <channel> :End of /NAMES list"`
### Next: 

- [ ] Wait for the MODE command, to integrate the **symbols** (private, secret or public channel) in the function. They're in public by default for now.

cc @tmanolis @QnYosa 