### PR TITLE
New feature : Part command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CXX			= c++
 
 DEP			= ${OBJS:%.o=%.d}
 
-CPPFLAGS	= -Wall -Wextra -Wunused -MMD -MP -g3 -std=c++98 -c -I includes/ 
+CPPFLAGS	= -Wall -Wextra -Werror -MMD -MP -g3 -std=c++98 -c -I includes/ 
 
 RM 			= rm -f
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ SRCS		= main.cpp Client.cpp ManageServer.cpp Server.cpp parsing.cpp Channel.cpp 
 				commands/invite.cpp	\
 				commands/nick.cpp	\
 				commands/pass.cpp	\
-				commands/names.cpp
+				commands/names.cpp	\
+				commands/part.cpp
 
 DIR_SRCS	= srcs/
 

--- a/includes/Commands.hpp
+++ b/includes/Commands.hpp
@@ -32,6 +32,7 @@ void	names(Server *server, int const client_fd, cmd_struct cmd_infos);
 void	nick(Server *server, int const client_fd, cmd_struct cmd_infos);
 // void	oper(Server server, cmd_struct cmd_infos);
 int		pass(Server *server, int const client_fd, cmd_struct cmd_infos);
+void	part(Server *server, int const client_fd, cmd_struct cmd_infos);
 int		ping(int const client_fd, cmd_struct &cmd);
 // void	quit(Server server, cmd_struct cmd_infos);
 void	topic(Server *server, int const client_fd, cmd_struct cmd_infos);

--- a/includes/Commands.hpp
+++ b/includes/Commands.hpp
@@ -17,6 +17,7 @@ struct cmd_struct
 int			parseCommand(std::string cmd_line, cmd_struct &cmd_infos);
 Client&		retrieveClient(Server *server, int const client_fd);
 std::string	getListOfMembers(Channel &channel);
+std::string	getChannelName(std::string msg_to_parse);
 std::string	findNickname(std::string msg_to_parse);
 
 // #######################

--- a/includes/Numerical_replies.hpp
+++ b/includes/Numerical_replies.hpp
@@ -25,6 +25,9 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define ERR_NICKNAMEINUSE(client, nick) ("433 " + client + " " + nick + " :Nickname is already in use.\r\n")
 # define RPL_NICK(oclient, uclient, client) (":" + oclient + "!" + uclient + "@localhost NICK " +  client + "\r\n")
 
+// PART
+# define RPL_PART(username, nick, channel, reason) (":" + nick + "!" + username + "@localhost PART #" + channel + " " + (reason.empty() ? "." : reason ) + "\r\n")
+
 // PASS
 # define ERR_PASSWDMISMATCH(client) ("464 " + client + " :Password incorrect.\r\n")
 

--- a/srcs/ManageServer.cpp
+++ b/srcs/ManageServer.cpp
@@ -8,15 +8,6 @@ static int acceptSocket(int listenSocket)
 	return (accept(listenSocket, (sockaddr *)&client, &addr_size));
 }
 
-static void	addClient(int client_socket, std::vector<pollfd> &poll_fds)
-{
-	pollfd	client_pollfd;
-	client_pollfd.fd = client_socket;
-	client_pollfd.events = POLLIN | POLLOUT; // A surveiller - pourquoi pollout ?
-	poll_fds.push_back(client_pollfd);
-	std::cout << PURPLE << "ADDED CLIENT SUCCESSFULLY" << RESET << std::endl;
-}
-
 static void	tooManyClients(int client_socket)
 {
 	std::cout << RED << ERR_FULL_SERV << RESET << std::endl;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -284,7 +284,7 @@ void Server::execCommand(int const client_fd, std::string cmd_line)
 	// case 6: mode(this, client_fd, cmd_infos); break;
 	case 7: names(this, client_fd, cmd_infos); break;
 	case 8: nick(this, client_fd, cmd_infos); break;
-	// case 9: part(cmd_infos); break;
+	case 9: part(this, client_fd, cmd_infos); break;
 	case 10: ping(client_fd, cmd_infos); break;
 	// case 11: oper(this, cmd_infos); break;
   	// case 12: privmsg(cmd_infos); break;

--- a/srcs/commands/join.cpp
+++ b/srcs/commands/join.cpp
@@ -4,7 +4,6 @@
 #include "Commands.hpp"
 
 bool			containsAtLeastOneAlphaChar(std::string str);
-std::string		getChannelName(std::string msg_to_parse);
 std::string		retrieveKey(std::string msg_to_parse);
 void			addChannel(Server *server, std::string const &channelName);
 void			addClientToChannel(Server *server, std::string &channelName, Client &client);
@@ -138,22 +137,6 @@ bool		containsAtLeastOneAlphaChar(std::string str)
 			return (true);
 	}
 	return (false);
-}
-
-std::string	getChannelName(std::string msg_to_parse)
-{
-	std::cout << "The msg_to_parse looks like this : |" << msg_to_parse << "|" << std::endl;
-	// Expected output : | #foobar|
-	// Expected output 2 : | #foo,#bar fubar,foobar|
-
-	std::string channel_name;
-	size_t i = 0;
-	while (msg_to_parse[i] && (!isalpha(msg_to_parse[i]) && !isdigit(msg_to_parse[i]) && msg_to_parse[i] != '-' && msg_to_parse[i] != '_'))
-		i++;
-	while (msg_to_parse[i] && (isalpha(msg_to_parse[i]) || msg_to_parse[i] == '-' || msg_to_parse[i] == '_' || isdigit(msg_to_parse[i])))
-		channel_name += msg_to_parse[i++];
-	std::cout << "The channel name is : |" << channel_name << "|" << std::endl;
-	return (channel_name);
 }
 
 std::string	retrieveKey(std::string msg_to_parse)

--- a/srcs/commands/list.cpp
+++ b/srcs/commands/list.cpp
@@ -42,12 +42,13 @@ void		list(Server *server, int const client_fd, cmd_struct cmd_infos)
 		else 
 		{
 			std::map<std::string, Channel>::iterator it = server->getChannels().begin();
-			for (it; it != server->getChannels().end(); it++)
+			while (it != server->getChannels().end())
 			{
 				RPL_LIST.clear();
 				RPL_LIST = getRplList(client_nick, it);
 				send(client_fd, RPL_LIST.c_str(), RPL_LIST.size(), 0);
 				std::cout << "[Server] Message sent to client " << client_fd << " >> " << CYAN << RPL_LIST << RESET << std::endl;
+				it++;
 			}
 		}
 	}

--- a/srcs/commands/names.cpp
+++ b/srcs/commands/names.cpp
@@ -34,7 +34,7 @@ void	names(Server *server, int const client_fd, cmd_struct cmd_infos)
 	{
 		// find the channel to display names of
 		channel_to_name.clear();
-		channel_to_name = getChannelName(cmd_infos.message);
+		channel_to_name = getaChannelName(cmd_infos.message);
 		cmd_infos.message.erase(cmd_infos.message.find(channel_to_name), channel_to_name.length()); 
 
 		// Error handling (Inexistent channel, Secret Mode on...)

--- a/srcs/commands/names.cpp
+++ b/srcs/commands/names.cpp
@@ -4,7 +4,7 @@
 #include "Commands.hpp"
 
 static bool			containsAtLeastOneAlphaChar(std::string str);
-static std::string	getChannelName(std::string msg_to_parse);
+static std::string	getaChannelName(std::string msg_to_parse);
 // static std::string	getSymbol(Channel &channel);
 /**
  * @brief The NAMES command is used to view the nicknames joined to a channel.
@@ -70,7 +70,7 @@ static bool		containsAtLeastOneAlphaChar(std::string str)
 	return (false);
 }
 
-static std::string getChannelName(std::string msg_to_parse)
+static std::string getaChannelName(std::string msg_to_parse)
 {
 	std::string	channel_name;
 	size_t		i = 0;

--- a/srcs/commands/nick.cpp
+++ b/srcs/commands/nick.cpp
@@ -96,16 +96,14 @@ static bool	containsInvalidCharacters(std::string nickname)
 
 static bool	isAlreadyUsed(Server *server, std::string new_nickname)
 {
-	std::map<const int, Client>	client_list;
-	client_list = server->getClients();
+	std::map<const int, Client>&			client_list	= server->getClients();
+	std::map<const int, Client>::iterator	client		= client_list.begin();
 
-	std::map<const int, Client>::iterator	client;
-	client = client_list.begin();
-
-	for (client; client != client_list.end(); client++)
+	while (client != client_list.end())
 	{
 		if (client->second.getNickname() == new_nickname)
 			return (true);
+		client++;
 	}
 	return (false);
 }

--- a/srcs/commands/part.cpp
+++ b/srcs/commands/part.cpp
@@ -1,0 +1,44 @@
+#include "Irc.hpp"
+#include "Channel.hpp"
+#include "Server.hpp"
+#include "Commands.hpp"
+
+/**
+ * @brief The PART command removes the client from the given channel(s).
+ * 
+ * 	Syntax: PART <channel>{,<channel>} [<reason>]
+ * 
+ *  On sending a successful PART command, the user will receive a PART message 
+ *  from the server for each channel they have been removed from. 
+ *  <reason> is the reason that the client has left the channel(s).
+ * 
+ *  Numeric Replies:
+ *   ERR_NEEDMOREPARAMS (461)
+ *   ERR_NOSUCHCHANNEL (403)
+ *   ERR_NOTONCHANNEL (442)
+ * 	
+ * 	Example:
+ * 	[IRSSI] /PART #test,#hey Dining
+ * 	[SERVER] leaves both channels #test and #hey with the reason "Dining"
+ * 	[SERVER to CLIENT]"@user_id PART #channel :Dining" (for EACH channel they leave)
+ */
+void	part(Server *server, int const client_fd, cmd_struct cmd_infos)
+{
+
+	// find reason if there is one
+	// erase reason from msg
+
+	// tout mettre dans la meme boucle que join
+
+		// find channel
+		// erase channel from msg
+
+		
+		// if chan exists and client not in it => ERR_NOTONCHANNEL
+		// the chan will be ignored
+
+		// if chan does not exist => ERR_NOSUCHCHANNEL
+			// chan will be ignored
+		
+		// si chan valide, on envoie un message PART au client
+}

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -38,3 +38,19 @@ std::string	getListOfMembers(Channel &channel)
 		members_list.erase(members_list.end()-1);
 	return (members_list);
 }
+
+std::string	getChannelName(std::string msg_to_parse)
+{
+	std::cout << "The msg_to_parse looks like this : |" << msg_to_parse << "|" << std::endl;
+	// Expected output : | #foobar|
+	// Expected output 2 : | #foo,#bar fubar,foobar|
+
+	std::string channel_name;
+	size_t i = 0;
+	while (msg_to_parse[i] && (!isalpha(msg_to_parse[i]) && !isdigit(msg_to_parse[i]) && msg_to_parse[i] != '-' && msg_to_parse[i] != '_'))
+		i++;
+	while (msg_to_parse[i] && (isalpha(msg_to_parse[i]) || msg_to_parse[i] == '-' || msg_to_parse[i] == '_' || isdigit(msg_to_parse[i])))
+		channel_name += msg_to_parse[i++];
+	std::cout << "The channel name is : |" << channel_name << "|" << std::endl;
+	return (channel_name);
+}


### PR DESCRIPTION
- [x] `/PART` implemented. Enables the user to leave the channel(s), giving a reason or not. This alerts all of the members of said channel. Syntax is : `/PART <#channel>{,<#channel>}  <reason>`

- [x] Not relevant to this command, but I added the missing **-Werror** flag in the Makefile. Also **deleted the -Wunused** flag, so we are more rigourous (and the compiling looks neater! :) )

cc @tmanolis @QnYosa