### PR TITLE
[Fix] Nickname already used

### DIFF
--- a/includes/Commands.hpp
+++ b/includes/Commands.hpp
@@ -19,6 +19,7 @@ Client&		retrieveClient(Server *server, int const client_fd);
 std::string	getListOfMembers(Channel &channel);
 std::string	getChannelName(std::string msg_to_parse);
 std::string	findNickname(std::string msg_to_parse);
+bool		isAlreadyUsed(Server *server, int client_fd, std::string new_nickname);
 
 // #######################
 // ###### COMMANDS #######

--- a/includes/Numerical_replies.hpp
+++ b/includes/Numerical_replies.hpp
@@ -3,6 +3,8 @@
 
 void	sendServerRpl(int const client_fd, std::string reply);
 
+# define user_id(nickname, username) (":" + nickname + "!" + username + "@localhost")
+
 // INVITE
 # define ERR_NEEDMOREPARAMS(client, command) ("461 " + client + " " + command + " :Not enough parameters.\r\n")
 # define ERR_NOSUCHCHANNEL(client, channel) ("403 " + client + " " + channel + " :No such channel\r\n")
@@ -11,22 +13,22 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define RPL_INVITING(client, nick, channel) ("341 " + client + " " + nick + " " + channel + " :Is invited to a channel!\r\n")
 
 // JOIN
-# define RPL_JOIN(username, nick, channel) (":" + nick + "!" + username + "@localhost JOIN " +  channel + "\r\n")
+# define RPL_JOIN(username, nickname, channel) (":" + nickname + "!" + username + "@localhost JOIN " +  channel + "\r\n")
 # define ERR_BANNEDFROMCHAN(client, channel) ("474 " + client + " " + channel + " :Cannot join channel (+b)")
 # define ERR_BADCHANNELKEY(client, channel) ("475 " + client + " " + channel + " :Cannot join channel (+k)")
 
 // NAMES
-# define RPL_NAMREPLY(client, symbol, channel, list_of_nicks) ("353 " + client + " " + symbol + " " + channel + " :" + list_of_nicks + ".\r\n")
+# define RPL_NAMREPLY(client, symbol, channel, list_of_nicks) ("353 " + client + " " + symbol + " #" + channel + " :" + list_of_nicks + "\r\n")
 # define RPL_ENDOFNAMES(client, channel) ("366 " + client + " " + channel + " :End of /NAMES list\r\n")
 
 // NICK
 # define ERR_NONICKNAMEGIVEN(client) ("431 " + client + " :There is no nickname.\r\n")
-# define ERR_ERRONEUSNICKNAME(client, nick) ("432 " + client + " " + nick + " :Erroneus nickname\r\n")
-# define ERR_NICKNAMEINUSE(client, nick) ("433 " + client + " " + nick + " :Nickname is already in use.\r\n")
+# define ERR_ERRONEUSNICKNAME(client, nickname) ("432 " + client + " " + nickname + " :Erroneus nickname\r\n")
+# define ERR_NICKNAMEINUSE(client, nickname) ("433 " + client + " " + nickname + " :Nickname is already in use.\r\n")
 # define RPL_NICK(oclient, uclient, client) (":" + oclient + "!" + uclient + "@localhost NICK " +  client + "\r\n")
 
 // PART
-# define RPL_PART(username, nick, channel, reason) (":" + nick + "!" + username + "@localhost PART #" + channel + " " + (reason.empty() ? "." : reason ) + "\r\n")
+# define RPL_PART(user_id, channel, reason) (user_id + " PART #" + channel + " " + (reason.empty() ? "." : reason ) + "\r\n")
 
 // PASS
 # define ERR_PASSWDMISMATCH(client) ("464 " + client + " :Password incorrect.\r\n")
@@ -40,7 +42,8 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define RPL_NEWTOPIC(client, channel, topic) (client + " " + channel + " New topic is " + topic + "\r\n")
 # define RPL_DISPLAYTOPIC(client_id, channel) (client_id + " TOPIC " +  channel + "\r\n")
 
-
+// USER
+# define ERR_ALREADYREGISTERED(client) ("462 " + client + " :You may not reregister.\r\n")
 
 
 

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -175,7 +175,6 @@ void Server::fillClients(std::map<const int, Client> &client_list, int client_fd
 		cmd.erase(cmd.find("NICK"), 4);
 		cmd = cleanStr(cmd);
 		it->second.setNickname(cmd);
-		std::cout << "The username is |" << it->second.getNickname() << "|" << std::endl;
 		if (isAlreadyUsed(this, client_fd, it->second.getNickname()) == true)
 		{
 			sendServerRpl(client_fd, ERR_NICKNAMEINUSE(it->second.getNickname(), cmd));

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -175,6 +175,12 @@ void Server::fillClients(std::map<const int, Client> &client_list, int client_fd
 		cmd.erase(cmd.find("NICK"), 4);
 		cmd = cleanStr(cmd);
 		it->second.setNickname(cmd);
+		std::cout << "The username is |" << it->second.getNickname() << "|" << std::endl;
+		if (isAlreadyUsed(this, client_fd, it->second.getNickname()) == true)
+		{
+			sendServerRpl(client_fd, ERR_NICKNAMEINUSE(it->second.getNickname(), cmd));
+			it->second.setNickname(cmd.append("_"));
+		}
 	}
 	else if (cmd.find("USER") != std::string::npos)
 	{

--- a/srcs/commands/join.cpp
+++ b/srcs/commands/join.cpp
@@ -100,12 +100,13 @@ void	join(Server *server, int const client_fd, cmd_struct cmd_infos)
  * 	2) The channel's TOPIC if there is one (RPL_TOPIC)
  * 	3) The NAMES of the users in this channel
  *  
+ * [:msanjuan_!msanjuan@localhost 353 msanjuan_ = #hello :@msanjuan_ ]
  */
 void		sendChanInfos(Channel &channel, std::string channel_name, Client &client)
 {
 	int			client_fd	= client.getClientFd();
-	std::string	nick		= client.getUsername();
-	std::string username	= client.getNickname();
+	std::string	nick		= client.getNickname();
+	std::string username	= client.getUsername();
 	std::string	client_id	= ":" + nick + "!" + username + "@localhost";
  	
 	sendServerRpl(client_fd, RPL_JOIN(username, nick, channel_name));

--- a/srcs/commands/nick.cpp
+++ b/srcs/commands/nick.cpp
@@ -5,7 +5,6 @@
 
 std::string	retrieveNickname(std::string msg_to_parse);
 static bool	containsInvalidCharacters(std::string nickname);
-static bool	isAlreadyUsed(Server *server, std::string new_nickname);
 
 /**
  * @brief The NICK command is used to give the client a nickname or 
@@ -49,7 +48,7 @@ void	nick(Server *server, int const client_fd, cmd_struct cmd_infos)
 	else if (containsInvalidCharacters(nickname)) {
 		sendServerRpl(client_fd, ERR_ERRONEUSNICKNAME(client.getNickname(), nickname));
 	} 
-	else if (isAlreadyUsed(server, nickname) == true) {
+	else if (isAlreadyUsed(server, client_fd, nickname) == true) {
 		sendServerRpl(client_fd, ERR_NICKNAMEINUSE(client.getNickname(), nickname));
 	} else {
 		
@@ -94,14 +93,15 @@ static bool	containsInvalidCharacters(std::string nickname)
 	return (false);			
 }
 
-static bool	isAlreadyUsed(Server *server, std::string new_nickname)
+bool	isAlreadyUsed(Server *server, int client_fd, std::string new_nickname)
 {
 	std::map<const int, Client>&			client_list	= server->getClients();
 	std::map<const int, Client>::iterator	client		= client_list.begin();
 
 	while (client != client_list.end())
 	{
-		if (client->second.getNickname() == new_nickname)
+		if (client->second.getClientFd() != client_fd \
+			&& client->second.getNickname() == new_nickname)
 			return (true);
 		client++;
 	}

--- a/srcs/commands/part.cpp
+++ b/srcs/commands/part.cpp
@@ -58,7 +58,7 @@ void				part(Server *server, int const client_fd, cmd_struct cmd_infos)
 		else // c) if successful command
 		{
 			it->second.getClientList().erase(nick);
-			sendServerRpl(client_fd, RPL_PART(client.getUsername(), nick, channel, reason));
+			sendServerRpl(client_fd, RPL_PART(user_id(nick, client.getUsername()), channel, reason));
 			broadcastToAllChannelMembers(it->second, client.getUsername(), nick, reason);
 		}
 	}
@@ -92,7 +92,7 @@ static void			broadcastToAllChannelMembers(Channel &channel, std::string user, s
 	while (member != channel.getClientList().end())
 	{
 		sendServerRpl(member->second.getClientFd(),	\
-			RPL_PART(user, nick, channel.getName(), reason));
+			RPL_PART(user_id(nick, user), channel.getName(), reason));
 		member++;
 	}
 }

--- a/srcs/commands/part.cpp
+++ b/srcs/commands/part.cpp
@@ -5,7 +5,8 @@
 
 static std::string	getReason(std::string msg_to_parse);
 static bool			containsAtLeastOneAlphaChar(std::string str);
-static void			broadcastToAllChannelMembers(Channel &channel, std::string reason);
+// static void			broadcastToAllChannelMembers(Channel &channel, std::string reason);
+static void			broadcastToAllChannelMembers(Channel &channel, std::string user, std::string nick, std::string reason);
 
 /**
  * @brief The PART command removes the client from the given channel(s).
@@ -58,7 +59,7 @@ void				part(Server *server, int const client_fd, cmd_struct cmd_infos)
 		{
 			it->second.getClientList().erase(nick);
 			sendServerRpl(client_fd, RPL_PART(client.getUsername(), nick, channel, reason));
-			broadcastToAllChannelMembers(it->second, reason);
+			broadcastToAllChannelMembers(it->second, client.getUsername(), nick, reason);
 		}
 	}
 }
@@ -84,17 +85,14 @@ static bool			containsAtLeastOneAlphaChar(std::string str)
 	return (false);
 }
 
-static void			broadcastToAllChannelMembers(Channel &channel, std::string reason)
+static void			broadcastToAllChannelMembers(Channel &channel, std::string user, std::string nick, std::string reason)
 {
 	std::map<std::string, Client>::iterator member = channel.getClientList().begin();
 	
 	while (member != channel.getClientList().end())
 	{
 		sendServerRpl(member->second.getClientFd(),	\
-			RPL_PART(member->second.getUsername(),		\
-					member->second.getNickname(),		\
-					channel.getName(),					\
-					reason));
+			RPL_PART(user, nick, channel.getName(), reason));
 		member++;
 	}
 }


### PR DESCRIPTION
- [x] Client registration : added error handling when nickname was already taken

```cpp
if (cmd.find("NICK") != std::string::npos)
{
 cmd.erase(cmd.find("NICK"), 4);
 cmd = cleanStr(cmd);
 it->second.setNickname(cmd);
// Addition below
 if (isAlreadyUsed(this, client_fd, it->second.getNickname()) == true)
 {
   sendServerRpl(client_fd, ERR_NICKNAMEINUSE(it->second.getNickname(), cmd));
   it->second.setNickname(cmd.append("_"));
 }
}
```
- [x] Nick command : isAlreadyUsed() was missing an additional condition to work
```cpp
bool	isAlreadyUsed(Server *server, int client_fd, std::string new_nickname)
{
 std::map<const int, Client>&			client_list	= server->getClients();
 std::map<const int, Client>::iterator	client		= client_list.begin();

 while (client != client_list.end())
 {
   if (client->second.getClientFd() != client_fd \ // code added
    && client->second.getNickname() == new_nickname)
      return (true);
   client++;
 }
 return (false);
}
```

- [x] Part command : Now the window quits when someone w/ a modified nickname uses `/PART`. It also fixed the right amount of nicknames in the listing (found in `sendChanInfos()` function, in `join.cpp`)

> **LOGIC :** The issue did not come from the part functions, nor the numerical_replies macros... but from the join command, where I inverted the nick and user values by error (the server was sending JOIN values to **user!nick@host**, so ofc when you try to part w/ the correct syntax (nick!user@localhost), the client does not recognize it!).
