### PR TITLE
[QUIT] [VALGRIND] SIGPIPE when client quits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ SRCS		= main.cpp Client.cpp ManageServer.cpp Server.cpp parsing.cpp Channel.cpp 
 				commands/names.cpp	\
 				commands/part.cpp	\
 				commands/quit.cpp   \
-				commands/kick.cpp
+				commands/kick.cpp 	\
+				commands/oper.cpp
 
 DIR_SRCS	= srcs/
 

--- a/includes/Commands.hpp
+++ b/includes/Commands.hpp
@@ -32,7 +32,7 @@ void	kick(Server *server, int const client_fd, cmd_struct cmd_infos);
 void	list(Server *server, int const client_fd, cmd_struct cmd_infos);
 void	names(Server *server, int const client_fd, cmd_struct cmd_infos);
 void	nick(Server *server, int const client_fd, cmd_struct cmd_infos);
-// void	oper(Server server, cmd_struct cmd_infos);
+void	oper(Server *server, int const client_fd, cmd_struct cmd_infos);
 int		pass(Server *server, int const client_fd, cmd_struct cmd_infos);
 void	part(Server *server, int const client_fd, cmd_struct cmd_infos);
 int		ping(Server *server, int const client_fd, cmd_struct &cmd);

--- a/srcs/ManageServer.cpp
+++ b/srcs/ManageServer.cpp
@@ -94,6 +94,7 @@ int Server::manageServerLoop()
 					}
 					else if (read_count == 0) // when a client disconnects
 					{
+						std::cout << "CEST PAR ICI ?" << std::endl;
 						delClient(poll_fds, it->fd);
 						std::cout << "Disconnected\n";
 						if ((unsigned int)(poll_fds.size() - 1) == 0)

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -259,9 +259,9 @@ void Server::execCommand(int const client_fd, std::string cmd_line)
 		"MODE",
 		"NAMES",
 		"NICK",
+		"OPER",
 		"PART",
 		"PING",
-		"OPER",
 		"PRIVMSG",
 		"QUIT",
 		"TOPIC",
@@ -290,9 +290,9 @@ void Server::execCommand(int const client_fd, std::string cmd_line)
 		// case 6: mode(this, client_fd, cmd_infos); break;
 		case 7: names(this, client_fd, cmd_infos); break;
 		case 8: nick(this, client_fd, cmd_infos); break;
-		case 9: part(this, client_fd, cmd_infos); break;
-		case 10: ping(this, client_fd, cmd_infos); break;
-		// case 11: oper(this, cmd_infos); break;
+		case 9: oper(this, client_fd, cmd_infos); break;
+		case 10: part(this, client_fd, cmd_infos); break;
+		case 11: ping(this, client_fd, cmd_infos); break;
 		case 12: privmsg(this, client_fd, cmd_infos); break;
 		case 13: quit(this, client_fd, cmd_infos); break;
 		case 14: topic(this, client_fd, cmd_infos); break;

--- a/srcs/commands/oper.cpp
+++ b/srcs/commands/oper.cpp
@@ -1,6 +1,7 @@
 #include "Irc.hpp"
 #include "Channel.hpp"
 #include "Server.hpp"
+#include "Commands.hpp"
 
 /**
  * @brief The OPER command is used by a normal user to obtain IRC operator privileges.
@@ -20,40 +21,28 @@
  *  [CLIENT] OPER foo bar
  *  [SERVER] ; Attempt to register as an operator using a name of "foo" and the password "bar".
  */
-void oper(Server server, cmd_struct cmd_infos)
+void oper(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
-	// TODO: coder le parsing du command.message pour arriver à operator name, channelName et clientName
-	std::string channelName;
-	std::string operatorName;
-	std::string password;
-
-	std::map<std::string, Channel> channels = server.getChannels();
-	std::map<std::string, Channel>::iterator it;
-	it = channels.find(channelName);
-
-	if (password != it.getOperatorPassword()) // TODO: getter de opPwd à coder
-	{
-		std::cout << "Wrong Password\n";
-		return;
-	}
-	if (it == channels.end())
-	{
-		std::cout << "That channel doesn't exist\n";
-		return ;
-	}
-	if (it->second.isOperator(operatorName) == false)
-		it->second.addFirstOperator(operatorName); // NOTE: refacto cette fonction qui fait comme AddOperator
+	
 }
 
-// NOTE: dans quelle cadre nous sert cette fonction? pour du debug? 
-void	Server::printOper(std::string &channelName)
-{
-	std::map<std::string, Channel>::iterator it;
-	it = _channels.find(channelName);
-	if (it == _channels.end())
-	{
-		std::cout << "That channel doesn't exit\n";
-		return ;
-	}
-	it->second.printOperators();
-}
+// 
+// 	std::string operatorName;
+// 	std::string password;
+
+// 	std::map<std::string, Channel> channels = server.getChannels();
+// 	std::map<std::string, Channel>::iterator it;
+// 	it = channels.find(channelName);
+
+// 	if (password != it.getOperatorPassword()) 
+// 	{
+// 		std::cout << "Wrong Password\n";
+// 		return;
+// 	}
+// 	if (it == channels.end())
+// 	{
+// 		std::cout << "That channel doesn't exist\n";
+// 		return ;
+// 	}
+// 	if (it->second.isOperator(operatorName) == false)
+// 		it->second.addFirstOperator(operatorName); // NOTE: refacto cette fonction qui fait comme AddOperator

--- a/srcs/commands/oper.cpp
+++ b/srcs/commands/oper.cpp
@@ -23,7 +23,9 @@
  */
 void oper(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
-	
+	(void)server;
+	(void)client_fd;
+	(void)cmd_infos;
 }
 
 // 

--- a/srcs/commands/quit.cpp
+++ b/srcs/commands/quit.cpp
@@ -3,6 +3,8 @@
 #include "Server.hpp"
 #include "Commands.hpp"
 
+static void			broadcastToChan(Channel &channel, int const client_fd, std::string nick, std::string user, std::string reason);
+
 /**
  * @brief The QUIT command is used to terminate a client’s connection to the server. 
  *  The server acknowledges this by replying with an ERROR message and closing 
@@ -21,14 +23,38 @@
  * 
  * 	Source: https://modern.ircdocs.horse/#quit-message
  */
-void	quit(Server *server, int const client_fd, cmd_struct cmd_infos)
+void		quit(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
-	Client 		&client = retrieveClient(server, client_fd);
-	std::string	reason	= getReason(cmd_infos.message);
+	Client& 								  client   = retrieveClient(server, client_fd);
+	std::string								  reason   = getReason(cmd_infos.message);
+	std::map<std::string, Channel>&			  channels = server->getChannels();
+	std::map<std::string, Channel>::iterator  chan	   = channels.begin();
 
-	(void)client;
-	(void)reason;
-	std::cout << "ASKSDKVJSKFGQK:WEF" << std::endl;
-	// sendServerRpl(client_fd, RPL_ERROR(user_id(client.getNickname(), client.getUsername()), reason));
-	// sendServerRpl(client_fd, RPL_QUIT(user_id(client.getNickname(), client.getUsername()), reason));
+	for (; chan != channels.end(); chan++) // check all channels
+	{
+		std::map<std::string, Client>& 			chan_members = chan->second.getClientList();
+		std::map<std::string, Client>::iterator	member		 = chan_members.begin();
+		for (; member != chan_members.end(); member++) // check all chan_members
+		{
+			if (member->second.getClientFd() == client_fd) // erase user from the chan + inform the others 
+			{
+				chan_members.erase(client.getNickname());
+				broadcastToChan(chan->second, client_fd, client.getNickname(), client.getUsername(), reason);
+				break ;
+			}
+		}
+	}
+}
+
+static void	broadcastToChan(Channel &channel, int const client_fd, std::string nick, std::string user, std::string reason)
+{
+	std::map<std::string, Client>::iterator member = channel.getClientList().begin();
+	
+	while (member != channel.getClientList().end())
+	{
+		if (member->second.getClientFd() != client_fd)
+			sendServerRpl(member->second.getClientFd(),	\
+			RPL_QUIT(user_id(nick, user), reason));
+		member++;
+	}
 }

--- a/srcs/commands/quit.cpp
+++ b/srcs/commands/quit.cpp
@@ -26,6 +26,9 @@ void	quit(Server *server, int const client_fd, cmd_struct cmd_infos)
 	Client 		&client = retrieveClient(server, client_fd);
 	std::string	reason	= getReason(cmd_infos.message);
 
-	sendServerRpl(client_fd, RPL_ERROR(user_id(client.getNickname(), client.getUsername()), reason));
-	sendServerRpl(client_fd, RPL_QUIT(user_id(client.getNickname(), client.getUsername()), reason));
+	(void)client;
+	(void)reason;
+	std::cout << "ASKSDKVJSKFGQK:WEF" << std::endl;
+	// sendServerRpl(client_fd, RPL_ERROR(user_id(client.getNickname(), client.getUsername()), reason));
+	// sendServerRpl(client_fd, RPL_QUIT(user_id(client.getNickname(), client.getUsername()), reason));
 }


### PR DESCRIPTION
Comme on l'a vu ensemble @tmanolis , les sendServerRpl au client qui quitte ont été supprimés!

`Quit` devient une fonction où : 

- [x] On checke si le user était dans un ou plusieurs channels; on l'efface le cas échéant

- [x] et on prévient les autres membres de ce/ces channel(s) avec un `RPL_QUIT` (cf.  [screen sur TRELLO](https://trello.com/c/CDzSu416/73-quit-valgrind-sigpipe))

Autres changements mineurs:
- j'avais checkout de oper_cmd pour créer la branche leaks, donc c'est pour ca que tu vois des modifs sur ce fichier (pas important)
- fiy, les modifs sur le switch viennent de la (j avais redéplacé oper avant les 'p')