### PR TITLE
Channel operator

### DIFF
--- a/srcs/commands/join.cpp
+++ b/srcs/commands/join.cpp
@@ -83,10 +83,8 @@ void	join(Server *server, int const client_fd, cmd_struct cmd_infos)
 		} 
 		else {
 			addClientToChannel(server, channel_name, client);
-			// if le channel a pas d'operateur :
 			if (it_chan->second.getOperators().empty())
 				it_chan->second.addFirstOperator(client.getNickname());
-			
 			sendChanInfos(it_chan->second, channel_name, client);
 		}
 	}

--- a/srcs/commands/list.cpp
+++ b/srcs/commands/list.cpp
@@ -92,9 +92,9 @@ static std::string	getRplList(std::string client_nick, std::map<std::string, Cha
 {
 	std::stringstream concat;
 		
-	concat << "322 " << client_nick << " " << channel->second.getName() << " "  \
-			<< channel->second.getClientList().size() \
-			<< (channel->second.getTopic().empty() ? " :No topic set for this channel yet."  : channel->second.getTopic()) \
+	concat << "322 " << client_nick << " #" << channel->second.getName() << " "  \
+			<< channel->second.getClientList().size() << " "\
+			<< (channel->second.getTopic().empty() ? ":No topic set for this channel yet."  : channel->second.getTopic()) \
 			<< "\r\n";
 	return (concat.str());			
 }

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -30,6 +30,8 @@ std::string	getListOfMembers(Channel &channel)
 	{
 		nick.clear();
 		nick = it->second.getNickname();
+		if (channel.isOperator(nick) == true)
+			members_list += "@";
 		members_list += nick;
 		members_list += " ";
 		it++;


### PR DESCRIPTION
Actually there is no RPL to send to make someone a channel operator (ChanOp, or Op in irssi).
**The only way to tell irssi a user is an operator is by prepending a "_@_" in the /names RPL.** Or to add the **mode +o** to the user. That way, when you join a channel, irssi prepends a @ before a nickname when privmessaging, or at the call of the /names command.