### PR TITLE
[CMD] Implement OPER

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ ircserv
 .nfs*
 **/.vscode/
 !.vscode/settings.json
+logs_test

--- a/includes/Numerical_replies.hpp
+++ b/includes/Numerical_replies.hpp
@@ -14,8 +14,8 @@ void	sendServerRpl(int const client_fd, std::string reply);
 
 // JOIN
 # define RPL_JOIN(username, nickname, channel) (":" + nickname + "!" + username + "@localhost JOIN " +  channel + "\r\n")
-# define ERR_BANNEDFROMCHAN(client, channel) ("474 " + client + " " + channel + " :Cannot join channel (+b)")
-# define ERR_BADCHANNELKEY(client, channel) ("475 " + client + " " + channel + " :Cannot join channel (+k)")
+# define ERR_BANNEDFROMCHAN(client, channel) ("474 " + client + " " + channel + " :Cannot join channel (+b)\r\n")
+# define ERR_BADCHANNELKEY(client, channel) ("475 " + client + " " + channel + " :Cannot join channel (+k)\r\n")
 
 // NAMES
 # define RPL_NAMREPLY(client, symbol, channel, list_of_nicks) ("353 " + client + " " + symbol + " #" + channel + " :" + list_of_nicks + "\r\n")
@@ -26,6 +26,10 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define ERR_ERRONEUSNICKNAME(client, nickname) ("432 " + client + " " + nickname + " :Erroneus nickname\r\n")
 # define ERR_NICKNAMEINUSE(client, nickname) ("433 " + client + " " + nickname + " :Nickname is already in use.\r\n")
 # define RPL_NICK(oclient, uclient, client) (":" + oclient + "!" + uclient + "@localhost NICK " +  client + "\r\n")
+
+// OPER
+# define ERR_NOOPERHOST(client) ("491 " + client + " :No O-lines for your host\r\n")
+# define RPL_YOUREOPER(client) ("381 " + client + " :You are now an IRC operator\r\n")
 
 // PART
 # define RPL_PART(user_id, channel, reason) (user_id + " PART #" + channel + " " + (reason.empty() ? "." : reason ) + "\r\n")

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -4,6 +4,15 @@
 #include "Irc.hpp"
 #include "Client.hpp"
 #include "Channel.hpp"
+#include <iostream>
+#include <fstream>
+
+struct server_op
+{
+	std::string name;
+	std::string	host;
+	std::string	password;
+};
 
 class Server
 {
@@ -13,9 +22,9 @@ class Server
 		int								_server_socket_fd;
 		std::map<const int, Client>		_clients;
 		std::map<std::string, Channel>	_channels;
-		// Commands						_cmd;
 		std::string						_port;
 		std::string						_password;
+		std::vector<server_op>			_irc_operators;
 	
 	public:
 		// Constructor & destructor
@@ -23,13 +32,15 @@ class Server
 		Server();
 		~Server();
 		// Accessors
-		void							setHints();
-		std::string						getPort() const;
-		std::string						getPassword() const;
+		void								setHints();
+		std::string							getPort() const;
+		std::string							getPassword() const;
 		void								setPassword(std::string new_pwd);
 		std::map<std::string, Channel>& 	getChannels();
 		std::map<const int, Client>&		getClients();
+		
 		// Running Server functions
+		int 		readFromConfigFile(char *filename);
 		int			fillServinfo(char *port);
 		int			launchServer();
 		int			manageServerLoop();

--- a/includes/Server.hpp
+++ b/includes/Server.hpp
@@ -38,6 +38,7 @@ class Server
 		void								setPassword(std::string new_pwd);
 		std::map<std::string, Channel>& 	getChannels();
 		std::map<const int, Client>&		getClients();
+		std::vector<server_op>&				getIrcOperators(); 
 		
 		// Running Server functions
 		int 		readFromConfigFile(char *filename);

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -7,7 +7,7 @@ Server::Server(std::string port, std::string password)
 {
 	std::cout << YELLOW << "Server Constructor" << RESET << std::endl;
 	memset(&_hints, 0, sizeof(_hints));
-	memset(&_irc_operators, 0, sizeof(_irc_operators));
+	// memset(&_irc_operators, 0, sizeof(_irc_operators));
 }
 
 Server::~Server()

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -39,6 +39,8 @@ std::map<std::string, Channel>&	Server::getChannels()		{ return (_channels); }
 
 std::map<const int, Client>&	Server::getClients()		{ return (_clients); }
 
+std::vector<server_op>&			Server::getIrcOperators()	{ return (_irc_operators); }
+
 void							Server::setPassword(std::string new_pwd)
 {
 	_password = new_pwd;

--- a/srcs/Server.cpp
+++ b/srcs/Server.cpp
@@ -7,6 +7,7 @@ Server::Server(std::string port, std::string password)
 {
 	std::cout << YELLOW << "Server Constructor" << RESET << std::endl;
 	memset(&_hints, 0, sizeof(_hints));
+	memset(&_irc_operators, 0, sizeof(_irc_operators));
 }
 
 Server::~Server()
@@ -41,6 +42,43 @@ std::map<const int, Client>&	Server::getClients()		{ return (_clients); }
 void							Server::setPassword(std::string new_pwd)
 {
 	_password = new_pwd;
+}
+
+/**
+ * @brief Get the name, host and password of all the irc operators from a file
+ * 
+ * @param file Str of the config file with all of infos
+ * @return int Returns SUCCESS (0) or FAILURE (-1)
+ */
+int 		Server::readFromConfigFile(char *filename)
+{
+	std::ifstream				data;
+	std::string					buffer;
+	std::vector<std::string>	operators;
+
+	data.open(filename);
+	if (!data)
+		return (FAILURE);
+	while (getline(data, buffer)) {
+		operators.push_back(buffer);
+	}
+	data.close();
+
+	std::vector<std::string>::iterator it;
+	for (it = operators.begin(); it != operators.end(); it++)
+	{
+		std::string	line = *it;
+		server_op	op;
+		
+		int len = line.size() - (line.size() - line.find_first_of(' '));
+
+		op.name.insert(0, line, 0, len);
+		op.host.insert(0, line, len + 1, line.find_last_of(' ') - len - 1);
+		op.password.insert(0, line, line.find_last_of(' ') + 1, line.size() - 1);
+		
+		_irc_operators.push_back(op);
+	}
+   return (SUCCESS);
 }
 
 /**

--- a/srcs/commands/oper.cpp
+++ b/srcs/commands/oper.cpp
@@ -24,6 +24,17 @@
 void oper(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
 	
+
+
+
+
+
+
+
+
+
+
+
 }
 
 // 

--- a/srcs/commands/oper.cpp
+++ b/srcs/commands/oper.cpp
@@ -23,17 +23,10 @@
  */
 void oper(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
-	
 
-
-
-
-
-
-
-
-
-
+	(void) server;
+	(void) client_fd;
+	(void) cmd_infos;
 
 }
 

--- a/srcs/commands/oper.cpp
+++ b/srcs/commands/oper.cpp
@@ -3,6 +3,8 @@
 #include "Server.hpp"
 #include "Commands.hpp"
 
+static std::string	getName(std::string msg_to_parse);
+static std::string	getPassword(std::string msg_to_parse);
 /**
  * @brief The OPER command is used by a normal user to obtain IRC operator privileges.
  * 	Both parameters are required for the command to be successful.
@@ -23,11 +25,47 @@
  */
 void oper(Server *server, int const client_fd, cmd_struct cmd_infos)
 {
+	Client&		client		= retrieveClient(server, client_fd);
+	std::string name		= getName(cmd_infos.message);
+	std::string password	= getPassword(cmd_infos.message);
 
-	(void) server;
-	(void) client_fd;
-	(void) cmd_infos;
+	if (name.empty() || password.empty())
+	{
+		sendServerRpl(client_fd, ERR_NEEDMOREPARAMS(client.getNickname(), cmd_infos.name));
+	}
+	else 
+	{
+		std::cout << "Name: |" << name << "|" << std::endl;
+		std::cout << "Password: |" << password << "|" << std::endl;
+	}
 
+}
+
+std::string	getName(std::string msg_to_parse)
+{
+	std::string name;
+
+	name.clear();
+	if (msg_to_parse.empty() == false || msg_to_parse.find(" ") != msg_to_parse.npos)
+	{
+		name.insert(0, msg_to_parse, 1,\
+					msg_to_parse.find_last_of(" ") - 1);
+	}
+	return (name);
+}
+
+std::string	getPassword(std::string msg_to_parse)
+{
+	std::string password;
+
+	password.clear();
+	if (msg_to_parse.empty() == false || msg_to_parse.find(" ") != msg_to_parse.npos)
+	{
+		password.insert(0, msg_to_parse,\
+					msg_to_parse.find_last_of(" ") + 1,\
+					msg_to_parse.size() - 1);
+	}
+	return (password);
 }
 
 // 

--- a/srcs/commands/oper.cpp
+++ b/srcs/commands/oper.cpp
@@ -33,10 +33,6 @@ void oper(Server *server, int const client_fd, cmd_struct cmd_infos)
 	std::string name		= getName(cmd_infos.message);
 	std::string password	= getPassword(cmd_infos.message);
 
-	// DEBUG
-	std::cout << "Name: |" << name << "|" << std::endl;
-	std::cout << "Password: |" << password << "|" << std::endl;
-
 	if (name.empty() || password.empty())
 	{
 		sendServerRpl(client_fd, ERR_NEEDMOREPARAMS(client.getNickname(), cmd_infos.name));
@@ -109,24 +105,3 @@ static std::string	getPassword(std::string msg_to_parse)
 	}
 	return (password);
 }
-
-// 
-// 	std::string operatorName;
-// 	std::string password;
-
-// 	std::map<std::string, Channel> channels = server.getChannels();
-// 	std::map<std::string, Channel>::iterator it;
-// 	it = channels.find(channelName);
-
-// 	if (password != it.getOperatorPassword()) 
-// 	{
-// 		std::cout << "Wrong Password\n";
-// 		return;
-// 	}
-// 	if (it == channels.end())
-// 	{
-// 		std::cout << "That channel doesn't exist\n";
-// 		return ;
-// 	}
-// 	if (it->second.isOperator(operatorName) == false)
-// 		it->second.addFirstOperator(operatorName); // NOTE: refacto cette fonction qui fait comme AddOperator

--- a/srcs/config/ManageServOperators.config
+++ b/srcs/config/ManageServOperators.config
@@ -1,0 +1,3 @@
+msanjuan localhost plouf
+tmanolis 127.0.0.1 bam
+dyoula localhost arbeit

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -5,9 +5,10 @@ int main (int argc, char **argv)
 	if (argc == 3)
 	{
 		Server server(argv[1], argv[2]);
-		// Server server;
 
-		// char port[5] = "6667";
+		char filename[39] = "srcs/config/ManageServOperators.config";
+		server.readFromConfigFile(filename);
+		
 		// The three following functions calls are just set up
 		server.setHints();
 		server.fillServinfo(argv[1]);


### PR DESCRIPTION
### [ARCHITECTURE]
- Added a config folder with a `ManageServerOperators` file with the scheme : `name host password`.

- Our Server class has now a vector of structs called `_irc_operators`.
```cpp
struct server_op
{
	std::string name;
	std::string host;
	std::string password;
};

std::vector<server_op> _irc_operators;
```
- The file is parsed to fill the vector `_irc_operators`.

### [OPER]

- Oper is actually **not** a command to make someone a channel operator! **Its purpose is to grant IRC server privileges** instead (like `QUIT`ting the server). So the whole function has a rework. We have to compare the name and password given to the ones  written in the configuration file.

- [x] Error handling: `ERR_PASSWDMISMATCH` and `ERR_NOOPERHOST`
- [x] Tested with `valgrind` : no additional still reachable or leaks!