### PR TITLE
[Fix] Channel changes by one user are updated for all the others

### DIFF
--- a/includes/Numerical_replies.hpp
+++ b/includes/Numerical_replies.hpp
@@ -6,16 +6,16 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define user_id(nickname, username) (":" + nickname + "!" + username + "@localhost")
 
 // INVITE
-# define ERR_NEEDMOREPARAMS(client, command) ("461 " + client + " " + command + " :Not enough parameters.\r\n")
-# define ERR_NOSUCHCHANNEL(client, channel) ("403 " + client + " " + channel + " :No such channel\r\n")
-# define ERR_NOTONCHANNEL(client, channel) ("442 " + client + " " + channel + " :The user is not on this channel.\r\n")
-# define ERR_USERONCHANNEL(client, nick, channel) ("443 " + client + " " + nick + " " + channel + " :Is already on channel\r\n")
-# define RPL_INVITING(client, nick, channel) ("341 " + client + " " + nick + " " + channel + " :Is invited to a channel!\r\n")
+# define ERR_NEEDMOREPARAMS(client, command) (":localhost 461 " + client + " " + command + " :Not enough parameters.\r\n")
+# define ERR_NOSUCHCHANNEL(client, channel) (":localhost 403 " + client + " #" + channel + " :No such channel\r\n")
+# define ERR_NOTONCHANNEL(client, channel) (":localhost 442 " + client + " #" + channel + " :The user is not on this channel.\r\n")
+# define ERR_USERONCHANNEL(client, nick, channel) (":localhost 443 " + client + " " + nick + " #" + channel + " :Is already on channel\r\n")
+# define RPL_INVITING(client, nick, channel) ("341 " + client + " " + nick + " #" + channel + " :Is invited to a channel!\r\n")
 
 // JOIN
 # define RPL_JOIN(user_id, channel) (user_id + " JOIN :#" +  channel + "\r\n")
-# define ERR_BANNEDFROMCHAN(client, channel) ("474 " + client + " " + channel + " :Cannot join channel (+b)\r\n")
-# define ERR_BADCHANNELKEY(client, channel) ("475 " + client + " " + channel + " :Cannot join channel (+k)\r\n")
+# define ERR_BANNEDFROMCHAN(client, channel) ("474 " + client + " #" + channel + " :Cannot join channel (+b)\r\n")
+# define ERR_BADCHANNELKEY(client, channel) ("475 " + client + " #" + channel + " :Cannot join channel (+k)\r\n")
 
 // KICK
 # define ERR_USERNOTINCHANNEL(client, nickname, channel) ("441 " + client + " " + nickname + " #" +  channel + " :They aren't on that channel\r\n")
@@ -56,13 +56,11 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define RPL_PRIVMSG(nick, username, message) (":" + nick + "!" + username + "@localhost PRIVMSG" + message + "\r\n")
 
 // TOPIC
-# define RPL_TOPIC(client, channel, topic) ("332 " + client + " #" + channel + " " + topic + "\r\n")
-# define RPL_NOTOPIC(client, channel) ("331 " + client + " " + channel + ": The topic has been cleared.\r\n")
-# define RPL_NEWTOPIC(client, channel, topic) (client + " " + channel + " New topic is " + topic + "\r\n")
-# define RPL_DISPLAYTOPIC(client_id, channel) (client_id + " TOPIC " +  channel + "\r\n")
+# define RPL_TOPIC(client, channel, topic) (":localhost 332 " + client + " #" + channel + " " + topic + "\r\n")
+# define RPL_NOTOPIC(client, channel) (":localhost 331 " + client + " #" + channel + " :No topic is set\r\n")
 
 // USER
-# define ERR_ALREADYREGISTERED(client) ("462 " + client + " :You may not reregister.\r\n")
+# define ERR_ALREADYREGISTERED(client) (":localhost 462 " + client + " :You may not reregister.\r\n")
 
 
 

--- a/includes/Numerical_replies.hpp
+++ b/includes/Numerical_replies.hpp
@@ -13,7 +13,7 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define RPL_INVITING(client, nick, channel) ("341 " + client + " " + nick + " " + channel + " :Is invited to a channel!\r\n")
 
 // JOIN
-# define RPL_JOIN(username, nickname, channel) (":" + nickname + "!" + username + "@localhost JOIN #" +  channel + "\r\n")
+# define RPL_JOIN(user_id, channel) (user_id + " JOIN :#" +  channel + "\r\n")
 # define ERR_BANNEDFROMCHAN(client, channel) ("474 " + client + " " + channel + " :Cannot join channel (+b)\r\n")
 # define ERR_BADCHANNELKEY(client, channel) ("475 " + client + " " + channel + " :Cannot join channel (+k)\r\n")
 
@@ -23,8 +23,8 @@ void	sendServerRpl(int const client_fd, std::string reply);
 # define RPL_KICK(user_id, channel, kicked, reason) (user_id + " KICK #" + channel + " " + kicked + " " + reason + "\r\n")
 
 // NAMES
-# define RPL_NAMREPLY(client, symbol, channel, list_of_nicks) ("353 " + client + " " + symbol + " #" + channel + " :" + list_of_nicks + "\r\n")
-# define RPL_ENDOFNAMES(client, channel) ("366 " + client + " " + channel + " :End of /NAMES list\r\n")
+# define RPL_NAMREPLY(client, symbol, channel, list_of_nicks) (":localhost 353 " + client + " " + symbol + " #" + channel + " :" + list_of_nicks + "\r\n")
+# define RPL_ENDOFNAMES(client, channel) (":localhost 366 " + client + " #" + channel + " :End of /NAMES list.\r\n")
 
 // NICK
 # define ERR_NONICKNAMEGIVEN(client) ("431 " + client + " :There is no nickname.\r\n")

--- a/srcs/commands/join.cpp
+++ b/srcs/commands/join.cpp
@@ -100,7 +100,6 @@ void	join(Server *server, int const client_fd, cmd_struct cmd_infos)
  *  
  * [:msanjuan_!msanjuan@localhost 353 msanjuan_ = #hello :@msanjuan_ ]
  */
-//TODO: mettre cette fonction dans la classe chan!!!!!! pour que topic soit updaté!!
 void		sendChanInfos(Channel &channel, std::string channel_name, Client &client)
 {
 	// int			client_fd	= client.getClientFd();

--- a/srcs/commands/join.cpp
+++ b/srcs/commands/join.cpp
@@ -115,10 +115,8 @@ void		sendChanInfos(Channel &channel, std::string channel_name, Client &client)
 		sendServerRpl(member->second.getClientFd(), RPL_JOIN(user_id(nick, username), channel_name));
 		if (channel.getTopic().empty() == false)
 		{
-			std::cout << "je rentre jamais dedans wllh" << std::endl;
 			client_id	= ":" + member->second.getNickname() + "!" + member->second.getUsername() + "@localhost";
-			sendServerRpl(member->second.getClientFd(), RPL_TOPIC(client_id, channel_name, channel.getTopic()));
-			sendServerRpl(member->second.getClientFd(), RPL_DISPLAYTOPIC(client_id, channel_name));
+			sendServerRpl(member->second.getClientFd(), RPL_TOPIC(nick, channel_name, channel.getTopic()));
 		}
 		
 		std::string	list_of_members = getListOfMembers(channel);

--- a/srcs/commands/join.cpp
+++ b/srcs/commands/join.cpp
@@ -100,24 +100,33 @@ void	join(Server *server, int const client_fd, cmd_struct cmd_infos)
  *  
  * [:msanjuan_!msanjuan@localhost 353 msanjuan_ = #hello :@msanjuan_ ]
  */
+//TODO: mettre cette fonction dans la classe chan!!!!!! pour que topic soit updaté!!
 void		sendChanInfos(Channel &channel, std::string channel_name, Client &client)
 {
-	int			client_fd	= client.getClientFd();
+	// int			client_fd	= client.getClientFd();
 	std::string	nick		= client.getNickname();
 	std::string username	= client.getUsername();
 	std::string	client_id	= ":" + nick + "!" + username + "@localhost";
  	
-	sendServerRpl(client_fd, RPL_JOIN(username, nick, channel_name));
-	if (channel.getTopic().empty() == false)
+	std::map<std::string, Client>::iterator member = channel.getClientList().begin();
+
+	while (member != channel.getClientList().end())
 	{
-		sendServerRpl(client_fd, RPL_TOPIC(client_id, channel_name, channel.getTopic()));
-		sendServerRpl(client_fd, RPL_DISPLAYTOPIC(client_id, channel_name));
+		sendServerRpl(member->second.getClientFd(), RPL_JOIN(user_id(nick, username), channel_name));
+		if (channel.getTopic().empty() == false)
+		{
+			std::cout << "je rentre jamais dedans wllh" << std::endl;
+			client_id	= ":" + member->second.getNickname() + "!" + member->second.getUsername() + "@localhost";
+			sendServerRpl(member->second.getClientFd(), RPL_TOPIC(client_id, channel_name, channel.getTopic()));
+			sendServerRpl(member->second.getClientFd(), RPL_DISPLAYTOPIC(client_id, channel_name));
+		}
+		
+		std::string	list_of_members = getListOfMembers(channel);
+		std::string symbol			= "=";
+		sendServerRpl(member->second.getClientFd(), RPL_NAMREPLY(username, symbol, channel_name, list_of_members));
+		sendServerRpl(member->second.getClientFd(), RPL_ENDOFNAMES(username, channel_name));
+		member++;
 	}
-	
-	std::string	list_of_members = getListOfMembers(channel);
-	std::string symbol			= "=";
-	sendServerRpl(client_fd, RPL_NAMREPLY(username, symbol, channel_name, list_of_members));
-	sendServerRpl(client_fd, RPL_ENDOFNAMES(username, channel_name));
 }
 
 bool		containsAtLeastOneAlphaChar(std::string str)


### PR DESCRIPTION
Include:
- `/topic` changes (refacto of function, change in RPL, broadcast of change)
- `/names` changes (broadcast of change)
- `/join` (broadcast in sendChanInfos)

The numerical replies are improved : 
- for _ERR_s_, prepend the host (i.e localhost) at the entire sentence
- for _channels_, prepend '#' at the channel_name