### PR TITLE
[CMD PARSING]

### DIFF
--- a/srcs/ManageServer.cpp
+++ b/srcs/ManageServer.cpp
@@ -89,7 +89,7 @@ int Server::manageServerLoop()
 					else
 					{
 						print("[Client] Message received from client ", it->fd, message); // si affichage incoherent regarder ici
-						if (message)
+						// if (message)
 							client->setReadBuffer(message);
 						// std::cout << "BUFFER |" << client->getReadBuffer() << "|" << std::endl;
 						if (client->getReadBuffer().find("\r\n") != std::string::npos)

--- a/srcs/ManageServer.cpp
+++ b/srcs/ManageServer.cpp
@@ -89,15 +89,22 @@ int Server::manageServerLoop()
 					else
 					{
 						print("[Client] Message received from client ", it->fd, message); // si affichage incoherent regarder ici
-						client->setReadBuffer(message);
-						std::cout << "BUFFER |" << client->getReadBuffer() << "|" << std::endl;
+						if (message)
+							client->setReadBuffer(message);
+						// std::cout << "BUFFER |" << client->getReadBuffer() << "|" << std::endl;
 						if (client->getReadBuffer().find("\r\n") != std::string::npos)
 						{
 							try 
 							{
+								// std::cout << "JE PARSE LE MESSAGE et le buffer est |" << client->getReadBuffer() << "|" << std::endl;
 								parseMessage(it->fd, client->getReadBuffer());
 								if (client->getReadBuffer().find("\r\n"))
-									client->resetReadBuffer("");
+								{
+									client->getReadBuffer().clear();
+									// client->resetReadBuffer("");
+								}
+									
+								// std::cout << "JAI FINI et le buffer est |" << client->getReadBuffer() << "|" << std::endl;
 							}
 							catch(const std::exception& e) 
 							{ 
@@ -108,6 +115,7 @@ int Server::manageServerLoop()
 								break ;
 							}
 						}
+						// std::cout << " APRES parsemsg, le buffer est |" << client->getReadBuffer() << "|" << std::endl;
 						it++;
 					}
 				}

--- a/srcs/ManageServerUtils.cpp
+++ b/srcs/ManageServerUtils.cpp
@@ -10,8 +10,12 @@ int	Server::handlePolloutEvent(std::vector<pollfd>& poll_fds, std::vector<pollfd
 	else
 	{
 		sendServerRpl(current_fd, client->getSendBuffer());
-		if (client->getReadBuffer().find("\r\n"))
-			client->getReadBuffer().clear();
+		// if (client->getReadBuffer().find("\r\n"))
+		// {
+		// 	std::cout << "A LA FIN DE MON SEND et le buffer est |" << client->getReadBuffer() << "|" << std::endl;
+		// 	client->getReadBuffer().clear();
+		// }
+			
 		client->getSendBuffer().clear();
 		if (client->getDeconnexionStatus() == true)
 		{

--- a/srcs/class/Client.cpp
+++ b/srcs/class/Client.cpp
@@ -38,6 +38,13 @@ int				Client::getNbInfo() const 		{ return (_nbInfo); }
 void	Client::setReadBuffer(std::string const &buf)
 {
 	_readbuf += buf;
+	// if (_readbuf.empty() == false && _readbuf[0] == ' \r')
+	// {
+	// 	if (_readbuf[1] && _readbuf[1] == '\n')
+	// 		_readbuf.erase(0, 2);
+	// 	else
+	// 		_readbuf.erase(0,1);
+	// }
 }
 
 void	Client::resetReadBuffer(std::string const &str)

--- a/srcs/class/Server.cpp
+++ b/srcs/class/Server.cpp
@@ -218,8 +218,10 @@ void Server::fillClients(std::map<const int, Client> &client_list, int client_fd
 {
 	std::map<const int, Client>::iterator it = client_list.find(client_fd);
 	cmd_struct cmd_infos;
-	parseCommand(cmd, cmd_infos);
+	if (parseCommand(cmd, cmd_infos) == FAILURE)
+		return ;
 
+	std::cout << "OH OH JE SUIS LA" << std::endl;
 	if (cmd.find("NICK") != std::string::npos)
 		nick(this, client_fd, cmd_infos);
 	else if (cmd.find("USER") != std::string::npos)
@@ -231,6 +233,7 @@ void Server::fillClients(std::map<const int, Client> &client_list, int client_fd
 		else
 			it->second.setConnexionPassword(false);
 	}
+	std::cout << "sortie des commandes" << std::endl;
 }
 
 static void splitMessage(std::vector<std::string> &cmds, std::string msg)
@@ -311,7 +314,8 @@ void Server::execCommand(int const client_fd, std::string cmd_line)
 	cmd_struct cmd_infos;
 	int index = 0;
 
-	parseCommand(cmd_line, cmd_infos);
+	if (parseCommand(cmd_line, cmd_infos) == FAILURE)
+		return ;
 
 	while (index < VALID_LEN)
 	{
@@ -319,7 +323,7 @@ void Server::execCommand(int const client_fd, std::string cmd_line)
 			break;
 		index++;
 	}
-
+	std::cout << "sortie de parse command" << std::endl;
 	switch (index + 1)
 	{
 		case 1: invite(this, client_fd, cmd_infos); break;

--- a/srcs/class/Server.cpp
+++ b/srcs/class/Server.cpp
@@ -221,7 +221,7 @@ void Server::fillClients(std::map<const int, Client> &client_list, int client_fd
 	if (parseCommand(cmd, cmd_infos) == FAILURE)
 		return ;
 
-	std::cout << "OH OH JE SUIS LA" << std::endl;
+	// std::cout << "OH OH JE SUIS LA" << std::endl;
 	if (cmd.find("NICK") != std::string::npos)
 		nick(this, client_fd, cmd_infos);
 	else if (cmd.find("USER") != std::string::npos)
@@ -233,7 +233,7 @@ void Server::fillClients(std::map<const int, Client> &client_list, int client_fd
 		else
 			it->second.setConnexionPassword(false);
 	}
-	std::cout << "sortie des commandes" << std::endl;
+	// std::cout << "sortie des commandes" << std::endl;
 }
 
 static void splitMessage(std::vector<std::string> &cmds, std::string msg)
@@ -257,7 +257,7 @@ void Server::parseMessage(int const client_fd, std::string message)
 
 	splitMessage(cmds, message);
 
-	std::cout << "je rerentre dedans" << std::endl;
+	// std::cout << "je rerentre dedans" << std::endl;
 	for (size_t i = 0; i != cmds.size(); i++)
 	{
 		if (it->second.isRegistrationDone() == false)
@@ -323,7 +323,7 @@ void Server::execCommand(int const client_fd, std::string cmd_line)
 			break;
 		index++;
 	}
-	std::cout << "sortie de parse command" << std::endl;
+	// std::cout << "sortie de parse command" << std::endl;
 	switch (index + 1)
 	{
 		case 1: invite(this, client_fd, cmd_infos); break;

--- a/srcs/commands/invite.cpp
+++ b/srcs/commands/invite.cpp
@@ -64,7 +64,10 @@ void	invite(Server *server, int const client_fd, cmd_struct cmd_infos)
 std::string	findNickname(std::string msg_to_parse)
 {
 	std::string nickname;
+	nickname.clear();
 	
+	if (msg_to_parse.empty() == true)
+		return (nickname);
 	char *str = const_cast<char *>(msg_to_parse.data());
 	nickname = strtok(str, " ");
 	

--- a/srcs/commands/kick.cpp
+++ b/srcs/commands/kick.cpp
@@ -80,9 +80,9 @@ void				kick(Server *server, int const client_fd, cmd_struct cmd_infos)
 	}
 	else
 	{
+		broadcastToChannel(server, it_chan->second, requester, kicked_name, reason);
 		it_chan->second.getClientList().erase(kicked_name);
 		it_chan->second.addToKicked(kicked_name);
-		broadcastToChannel(server, it_chan->second, requester, kicked_name, reason);
 	}
 }
 

--- a/srcs/commands/names.cpp
+++ b/srcs/commands/names.cpp
@@ -30,6 +30,11 @@ void	names(Server *server, int const client_fd, cmd_struct cmd_infos)
 	std::string		channel_to_name;
 	std::string		list_of_members;
 
+	if (cmd_infos.message.empty() == true)
+	{
+		addToClientBuffer(server, client_fd, ERR_NEEDMOREPARAMS(client.getNickname(), cmd_infos.name));
+		return ;
+	}
 	while (containsAtLeastOneAlphaChar(cmd_infos.message) == true)
 	{
 		// find the channel to display names of

--- a/srcs/commands/part.cpp
+++ b/srcs/commands/part.cpp
@@ -32,6 +32,11 @@ void				part(Server *server, int const client_fd, cmd_struct cmd_infos)
 	std::string	channel;
 
 	std::string reason = getReason(cmd_infos.message);
+	if (cmd_infos.message.empty() == true)
+	{
+		addToClientBuffer(server, client_fd, ERR_NEEDMOREPARAMS(nick, cmd_infos.name));
+		return ;
+	}
 	cmd_infos.message.erase(cmd_infos.message.find(reason), reason.length()); // #chan reason" becomes "#chan "
 
 	while (containsAtLeastOneAlphaChar(cmd_infos.message) == true)

--- a/srcs/commands/pass.cpp
+++ b/srcs/commands/pass.cpp
@@ -25,25 +25,33 @@ int		pass(Server *server, int const client_fd, cmd_struct cmd_infos)
 	Client&		client		= retrieveClient(server, client_fd);
 	std::string	password	= retrievePassword(cmd_infos.message);
 
-	if (server->getPassword() == password)
+
+	if (cmd_infos.message.empty() == true || password.empty() == true)
 	{
-		client.setNbInfo(+1);
-		return (SUCCESS);
+		addToClientBuffer(server, client_fd, ERR_NEEDMOREPARAMS(client.getNickname(), cmd_infos.name));
+		return (FAILURE);
 	}
-	else
+	else if (server->getPassword() != password)
 	{
 		addToClientBuffer(server, client_fd, ERR_PASSWDMISMATCH(client.getNickname()));
 		if (client.isRegistrationDone() == false)
 			client.setNbInfo(-1);
 		return (FAILURE);
 	}
+	else
+	{
+		client.setNbInfo(+1);
+		return (SUCCESS);
+	}
 }
 
 std::string	retrievePassword(std::string msg_to_parse)
 {
 	std::string	password;
-
 	size_t i = 0;
+	
+	password.clear();
+	
 	while (msg_to_parse[i] && msg_to_parse[i] == ' ')
 		i++;
 	while (msg_to_parse[i] && msg_to_parse[i] != ' ')

--- a/srcs/commands/quit.cpp
+++ b/srcs/commands/quit.cpp
@@ -30,6 +30,9 @@ void		quit(Server *server, int const client_fd, cmd_struct cmd_infos)
 	std::map<std::string, Channel>&			  channels = server->getChannels();
 	std::map<std::string, Channel>::iterator  chan	   = channels.begin();
 
+	// inform the concerned user
+	addToClientBuffer(server, client_fd, RPL_QUIT(user_id(client.getNickname(), client.getUsername()), reason));
+	// inform all the users that share a channel w/ the user quitting
 	for (; chan != channels.end(); chan++) // check all channels
 	{
 		std::map<std::string, Client>& 			chan_members = chan->second.getClientList();
@@ -53,6 +56,7 @@ static void	broadcastToChan(Server *server, Channel &channel, int const client_f
 {
 	std::map<std::string, Client>::iterator member = channel.getClientList().begin();
 	
+	(void) client_fd;
 	while (member != channel.getClientList().end())
 	{
 		if (member->second.getClientFd() != client_fd)

--- a/srcs/parsing.cpp
+++ b/srcs/parsing.cpp
@@ -10,16 +10,28 @@
  */
 int	parseCommand(std::string cmd_line, cmd_struct &cmd_infos)
 {
+	if (cmd_line.empty() == true)
+		return (FAILURE);
+	
+	std::cout << "Cmd_line : |" << cmd_line << "|" << std::endl;
+
 	// COMMAND
 	std::string copy = cmd_line;
-	if (cmd_line[0] == ':')
+	if (cmd_line.empty() == false && cmd_line[0] == ':')	// Cas du préfixe (supprimer cette partie d'une copy) pour retomber sur un cas "CMD arg <arg2>" ou "CMD"
 		copy.erase(0, copy.find_first_of(' '));
-	cmd_infos.name.insert(0, copy, 0, copy.find_first_of(' '));
-	
+	if (copy.find_first_of(' ') == std::string::npos) // Cas d'une commande "NICK" ou ":prefixe NICK" sans arguments
+	{
+		cmd_infos.name.insert(0, copy, 0, std::string::npos);
+		if (cmd_infos.name.find('\r') != std::string::npos) // effacer le \r\n, vu que dans ce cas on copie jusqu'à la fin
+			cmd_infos.name.erase(cmd_infos.name.find('\r'), 1); 
+	}
+	else
+		cmd_infos.name.insert(0, copy, 0, copy.find_first_of(' ')); // Cas d'une commande "NICK arg1" : on copie jusqu'à l'espace
+	std::cout << "Command : " << RED << cmd_infos.name << RESET << std::endl;
 	// PREFIX
 	size_t prefix_length = cmd_line.find(cmd_infos.name, 0);
 	cmd_infos.prefix.assign(cmd_line, 0, prefix_length);
-	
+	std::cout << "Prefix : " << BLUE << cmd_infos.prefix << RESET << std::endl;
 	// MESSAGE
 	size_t msg_beginning = cmd_line.find(cmd_infos.name, 0) + cmd_infos.name.length();
 	cmd_infos.message = cmd_line.substr(msg_beginning, std::string::npos);
@@ -29,8 +41,8 @@ int	parseCommand(std::string cmd_line, cmd_struct &cmd_infos)
 		cmd_infos.name[i] = std::toupper(cmd_infos.name[i]);
 	
 	// DEBUG
-	// std::cout << "Command : " << RED << cmd_infos.name << RESET << std::endl;
-	// std::cout << "Prefix : " << BLUE << cmd_infos.prefix << RESET << std::endl;
-	// std::cout << "Message : " << GREEN << cmd_infos.message << RESET << std::endl;
+	std::cout << "Command : " << RED << cmd_infos.name << RESET << std::endl;
+	std::cout << "Prefix : " << BLUE << cmd_infos.prefix << RESET << std::endl;
+	std::cout << "Message : " << GREEN << cmd_infos.message << RESET << std::endl;
 	return (SUCCESS);
 }

--- a/srcs/parsing.cpp
+++ b/srcs/parsing.cpp
@@ -17,8 +17,12 @@ int	parseCommand(std::string cmd_line, cmd_struct &cmd_infos)
 
 	// COMMAND
 	std::string copy = cmd_line;
-	if (cmd_line.empty() == false && cmd_line[0] == ':')	// Cas du préfixe (supprimer cette partie d'une copy) pour retomber sur un cas "CMD arg <arg2>" ou "CMD"
-		copy.erase(0, copy.find_first_of(' '));
+	if (cmd_line[0] == ':')	// Cas du préfixe (supprimer cette partie d'une copy) pour retomber sur un cas "CMD arg <arg2>" ou "CMD"
+	{
+		if (cmd_line.find_first_of(' ') != std::string::npos)
+			copy.erase(0, copy.find_first_of(' ') + 1);
+	}
+	// std::cout << "copy : |" << copy << "|" << std::endl;
 	if (copy.find_first_of(' ') == std::string::npos) // Cas d'une commande "NICK" ou ":prefixe NICK" sans arguments
 	{
 		cmd_infos.name.insert(0, copy, 0, std::string::npos);

--- a/srcs/parsing.cpp
+++ b/srcs/parsing.cpp
@@ -27,7 +27,7 @@ int	parseCommand(std::string cmd_line, cmd_struct &cmd_infos)
 	}
 	else
 		cmd_infos.name.insert(0, copy, 0, copy.find_first_of(' ')); // Cas d'une commande "NICK arg1" : on copie jusqu'à l'espace
-	std::cout << "Command : " << RED << cmd_infos.name << RESET << std::endl;
+	std::cout << "Command : |" << RED << cmd_infos.name << "|" << RESET << std::endl;
 	// PREFIX
 	size_t prefix_length = cmd_line.find(cmd_infos.name, 0);
 	cmd_infos.prefix.assign(cmd_line, 0, prefix_length);
@@ -41,8 +41,8 @@ int	parseCommand(std::string cmd_line, cmd_struct &cmd_infos)
 		cmd_infos.name[i] = std::toupper(cmd_infos.name[i]);
 	
 	// DEBUG
-	std::cout << "Command : " << RED << cmd_infos.name << RESET << std::endl;
-	std::cout << "Prefix : " << BLUE << cmd_infos.prefix << RESET << std::endl;
+	// std::cout << "Command : |" << RED << cmd_infos.name << "|" << RESET << std::endl;
+	// std::cout << "Prefix : " << BLUE << cmd_infos.prefix << RESET << std::endl;
 	std::cout << "Message : " << GREEN << cmd_infos.message << RESET << std::endl;
 	return (SUCCESS);
 }

--- a/srcs/parsing.cpp
+++ b/srcs/parsing.cpp
@@ -13,7 +13,7 @@ int	parseCommand(std::string cmd_line, cmd_struct &cmd_infos)
 	if (cmd_line.empty() == true)
 		return (FAILURE);
 	
-	std::cout << "Cmd_line : |" << cmd_line << "|" << std::endl;
+	// std::cout << "Cmd_line : |" << cmd_line << "|" << std::endl;
 
 	// COMMAND
 	std::string copy = cmd_line;
@@ -27,7 +27,7 @@ int	parseCommand(std::string cmd_line, cmd_struct &cmd_infos)
 	}
 	else
 		cmd_infos.name.insert(0, copy, 0, copy.find_first_of(' ')); // Cas d'une commande "NICK arg1" : on copie jusqu'à l'espace
-	std::cout << "Command : |" << RED << cmd_infos.name << "|" << RESET << std::endl;
+	std::cout << "Command : |" << RED << cmd_infos.name << RESET << "|"  << std::endl;
 	// PREFIX
 	size_t prefix_length = cmd_line.find(cmd_infos.name, 0);
 	cmd_infos.prefix.assign(cmd_line, 0, prefix_length);


### PR DESCRIPTION
Resolves #75, #70 

### ISSUE
A lot of segfault, caught exceptions when typing a command without any argument in NC. We did not see this error until now because we were testing w/ irssi, and irssi itself returns an error before the message is sent to our server so...


### SOLUTION
I improved the error handling in the function parseCommand (in parsing.cpp)
- Added case when there was a prefix
- Added case when there were no arguments


### WARNING
**Please test this in irssi before approving the PR:**

- [x]  Test a registration with a wrong password and not correct number of args for user 
- [x] For the following commands, test them without any argument after (even these are commands that should take args) :

- [x]  Registration : PASS, NICK, USER 
- [x]  OPER, KICK, INVITE, MODE, KILL
- [x]  JOIN, TOPIC, LIST, NAMES
- [x] NOTICE, PRIVMSG

Please not that NOTICE and PRIVMSG should bring a basic string exception that I did not correct because in your latest PR, the code has changed a lot so it seemed futile;

Also note that now, the registration should work in _any_ order (NICK, PASS, USER for instance), and that if you make a mistake in the process, should you correct it after, the welcome message should be sent ! (cf. PR on the register branch that was merged into main on Friday)
For instance:
```shell
PASS test
PASS good_pwd
NICK
NICK marine
USER m m
USER m m m m
```

### NEXT ? 

Keep in mind that this issue raised another one : I discovered that the buffer system we had was not proof-perfect! Still I want to do this PR because this new problem has nothing to do with the parsing.
Long story short : some buffers are not correctly concatenated or cleared (Idk yet), and in our switch, we have empty strings sent; as such we have a lot of spam of unknown commands on the client side!